### PR TITLE
WIP: Register a custom type

### DIFF
--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -5,10 +5,12 @@ require 'avro_turf/messaging'
 
 module Avromatic
   class << self
-    attr_accessor :schema_registry, :registry_url, :schema_store, :logger, :messaging
+    attr_accessor :schema_registry, :registry_url, :schema_store, :logger,
+                  :messaging, :custom_types
   end
 
   self.logger = Logger.new($stdout)
+  self.custom_types = {}
 
   def self.configure
     yield self
@@ -30,6 +32,12 @@ module Avromatic
 
   def self.build_messaging!
     self.messaging = build_messaging
+  end
+
+  def self.register_type(type_name, value_class = nil)
+    custom_types[type_name] = Avromatic::Model::CustomType.new(value_class).tap do |type|
+      yield(type) if block_given?
+    end
   end
 end
 

--- a/lib/avromatic/model.rb
+++ b/lib/avromatic/model.rb
@@ -1,5 +1,6 @@
 require 'avromatic/model/builder'
 require 'avromatic/model/decoder'
+require 'avromatic/model/custom_type'
 
 module Avromatic
   module Model

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -80,9 +80,16 @@ module Avromatic
           !optional?(field)
         end
 
+        # TODO: Introduce some kind of TypeRegistry?
+        def fetch_custom_type(field_type)
+          if field_type.respond_to?(:fullname)
+            Avromatic.custom_types[field_type.fullname]
+          end
+        end
+
         def avro_field_class(field_type)
-          if Avromatic.custom_types.key?(field_type.try(:fullname))
-            custom_type = Avromatic.custom_types[field_type.fullname]
+          custom_type = fetch_custom_type(field_type)
+          if custom_type
             value_class = custom_type.value_class
             return value_class if value_class
           end
@@ -129,8 +136,8 @@ module Avromatic
         def avro_field_options(field)
           options = {}
 
-          if Avromatic.custom_types.key?(field.type.try(:fullname))
-            custom_type = Avromatic.custom_types[field.type.fullname]
+          custom_type = fetch_custom_type(field.type)
+          if custom_type
             coercer = if custom_type.from_avro
                         custom_type.from_avro
                       elsif custom_type.value_class && custom_type.value_class.respond_to?(:from_avro)

--- a/lib/avromatic/model/configurable.rb
+++ b/lib/avromatic/model/configurable.rb
@@ -26,6 +26,12 @@ module Avromatic
           @key_avro_fields_by_name ||= mapped_by_name(key_avro_schema)
         end
 
+        # Store a hash of Procs by field name (as a symbol) to convert
+        # the value before Avro serialization.
+        def avro_coder
+          @avro_coder ||= {}
+        end
+
         private
 
         def mapped_by_name(schema)
@@ -36,7 +42,7 @@ module Avromatic
       end
 
       delegate :avro_schema, :value_avro_schema, :key_avro_schema,
-               :value_avro_field_names, :key_avro_field_names,
+               :value_avro_field_names, :key_avro_field_names, :avro_coder,
                to: :class
     end
   end

--- a/lib/avromatic/model/configuration.rb
+++ b/lib/avromatic/model/configuration.rb
@@ -1,7 +1,7 @@
 module Avromatic
   module Model
 
-    # This class holds configuration for a model build from Avro schema(s).
+    # This class holds configuration for a model built from Avro schema(s).
     class Configuration
 
       attr_reader :avro_schema, :key_avro_schema
@@ -17,7 +17,6 @@ module Avromatic
       # @option options [String, Symbol] :value_schema_name
       # @option options [Avro::Schema] :key_schema
       # @option options [String, Symbol] :key_schema_name
-      # @option options [schema store] :schema_store
       def initialize(**options)
         @avro_schema = find_avro_schema(**options)
         raise ArgumentError.new('value_schema(_name) or schema(_name) must be specified') unless avro_schema

--- a/lib/avromatic/model/custom_type.rb
+++ b/lib/avromatic/model/custom_type.rb
@@ -1,0 +1,13 @@
+module Avromatic
+  module Model
+
+    class CustomType
+
+      attr_accessor :to_avro, :from_avro, :value_class
+
+      def initialize(value_class)
+        @value_class = value_class
+      end
+    end
+  end
+end

--- a/lib/avromatic/model/serialization.rb
+++ b/lib/avromatic/model/serialization.rb
@@ -41,7 +41,7 @@ module Avromatic
             result[key.to_s] = if value.is_a?(Avromatic::Model::Attributes)
                                  value.value_attributes_for_avro
                                else
-                                 value
+                                 avro_coder[key].try(:call, value) || value
                                end
           end
         end

--- a/lib/avromatic/model/serialization.rb
+++ b/lib/avromatic/model/serialization.rb
@@ -41,7 +41,7 @@ module Avromatic
             result[key.to_s] = if value.is_a?(Avromatic::Model::Attributes)
                                  value.value_attributes_for_avro
                                else
-                                 avro_coder[key].try(:call, value) || value
+                                 (avro_coder[key] && avro_coder[key].call(value)) || value
                                end
           end
         end

--- a/spec/avro/dsl/test/named_type.rb
+++ b/spec/avro/dsl/test/named_type.rb
@@ -1,0 +1,7 @@
+namespace :test
+
+fixed :six, size: 6
+
+record :named_type  do
+  required :name, :six
+end

--- a/spec/avro/dsl/test/nested_record.rb
+++ b/spec/avro/dsl/test/nested_record.rb
@@ -1,0 +1,10 @@
+namespace :test
+
+record :nested_record do
+  required :str, :string, default: 'A'
+
+  required :sub, :record do
+    required :str, :string, default: 'B'
+    required :i, :int, default: 0
+  end
+end

--- a/spec/avro/schema/test/named_type.avsc
+++ b/spec/avro/schema/test/named_type.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "named_type",
+  "namespace": "test",
+  "fields": [
+    {
+      "name": "name",
+      "type": {
+        "name": "six",
+        "type": "fixed",
+        "namespace": "test",
+        "size": 6
+      }
+    }
+  ]
+}

--- a/spec/avro/schema/test/nested_record.avsc
+++ b/spec/avro/schema/test/nested_record.avsc
@@ -1,0 +1,32 @@
+{
+  "type": "record",
+  "name": "nested_record",
+  "namespace": "test",
+  "fields": [
+    {
+      "name": "str",
+      "type": "string",
+      "default": "A"
+    },
+    {
+      "name": "sub",
+      "type": {
+        "type": "record",
+        "name": "__nested_record_sub_record",
+        "namespace": "test",
+        "fields": [
+          {
+            "name": "str",
+            "type": "string",
+            "default": "B"
+          },
+          {
+            "name": "i",
+            "type": "int",
+            "default": 0
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/spec/model/builder_spec.rb
+++ b/spec/model/builder_spec.rb
@@ -248,6 +248,26 @@ describe Avromatic::Model::Builder do
     end
   end
 
+  # context "custom types" do
+  #   let(:schema_name) { 'test.named_type' }
+  #
+  #   before do
+  #     Avromatic.register_type('test.six') do |type|
+  #       type.to_avro = ->(value) { value.strip.downcase.ljust(6, '_') }
+  #       type.from_avro = ->(value) { value.strip.capitalize.rjust(6, '_') }
+  #     end
+  #   end
+  #
+  #   after do
+  #     Avromatic.custom_types.clear
+  #   end
+  #
+  #   let(:values) { { name: 'pERSON'} }
+  #
+  #   it ""
+  #
+  # end
+
   context "value objects" do
     let(:schema_name) { 'test.primitive_types' }
     let(:values) { { s: 'foo', tf: true, i: 42 } }

--- a/spec/model/serialization_spec.rb
+++ b/spec/model/serialization_spec.rb
@@ -24,6 +24,19 @@ describe Avromatic::Model::Serialization do
       decoded = test_class.deserialize(message_value)
       expect(decoded).to eq(instance)
     end
+
+    context "with a nested record" do
+      let(:test_class) do
+        Avromatic::Model.model(value_schema_name: 'test.nested_record')
+      end
+      let(:values) { { str: 'a', sub: { str: 'b', i: 1 } } }
+
+      it "encodes the value for the model" do
+        message_value = instance.avro_message_value
+        decoded = test_class.deserialize(message_value)
+        expect(decoded).to eq(instance)
+      end
+    end
   end
 
   describe "#avro_message_key" do


### PR DESCRIPTION
This is a very rough prototype for supporting custom types in generate models. The basic idea is to allow values to be stored in the model that require conversion to/from avro.

A `.from_avro` method (if defined on the value class) or a supplied proc is used as a coercer when values are assigned to the model.

A `.to_avro` method (if defined on the value class) or a supplied proc is used to prepare values before they are serialized using Avro.

An example configuration to use this is:

```ruby
Avromatic.configure do |config|
  config.register_type('com.salsify.salsify_uuid', SalsifyUuid) do |type|
    type.from_avro = ->(value) { SalsifyUuid.parse(value) }
    type.to_avro = ->(value) { value.to_s }
  end
end
```

Prime: @jturkel 