### PR TITLE
Add support for custom types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Allow the specification of a custom type, including conversion to/from Avro,
   for named types.
 
+## v0.3.0
+- Remove dependency on the `private_attr` gem.
+
 ## v0.2.0
 - Allow a module level schema registry to be configured.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # avromatic changelog
 
-## v0.3.0
-- Remove dependency on the `private_attr` gem.
+## v0.4.0
+- Allow the specification of a custom type, including conversion to/from Avro,
+  for named types.
 
 ## v0.2.0
 - Allow a module level schema registry to be configured.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 [travis]: http://travis-ci.org/salsify/avromatic
 
-`Avromatic` generates Ruby models from Avro schemas and provides utilities to
-encode and decode them.
+`Avromatic` generates Ruby models from [Avro](http://avro.apache.org/) schemas
+and provides utilities to encode and decode them.
 
 ## Installation
 
@@ -31,21 +31,31 @@ Or install it yourself as:
 
 * schema_registry: An `AvroTurf::SchemaRegistry` object used to store Avro schemas 
   so that they can be referenced by id. Either `schema_registry` or 
-  `registry_url` must be configured.
+  `registry_url` must be configured. See [Confluent Schema Registry](http://docs.confluent.io/2.0.1/schema-registry/docs/intro.html).
 * registry_url: URL for the schema registry. The schema registry is used to store
   Avro schemas so that they can be referenced by id.  Either `schema_registry` or 
   `registry_url` must be configured.
 * schema_store: The schema store is used to load Avro schemas from the filesystem.
   It should be an object that responds to `find(name, namespace = nil)` and
-  returns an `Avro::Schema` object.
+  returns an `Avro::Schema` object. An `AvroTurf::SchemaStore` can be used.
 * messaging: An `AvroTurf::Messaging` object to be shared by all generated models.
   The `build_messaging!` method may be used to create a `Messaging` instance based
   on the other configuration values.
-* logger: The logger is for the schema registry client.
+* logger: The logger to use for the schema registry client.
+* [Custom Types](#custom-types)
+
+Example:
+
+```ruby
+Avromatic.configure do |config|
+  config.schema_store = AvroTurf::SchemaStore.new(path: 'avro/schemas')
+  config.registry_url = Rails.configuration.x.avro_schema_registry_url
+  config.build_messaging!
+```
 
 ### Models
 
-Models may be defined based on an Avro schema for a record.
+Models are defined based on an Avro schema for a record.
 
 The Avro schema can be specified by name and loaded using the schema store:
 
@@ -61,13 +71,12 @@ Or an `Avro::Schema` object can be specified directly:
 class MyModel
   include Avromatic::Model.build(schema: schema_object)
 end
-
 ```
 
 Models are generated as [Virtus](https://github.com/solnic/virtus) value
 objects. `Virtus` attributes are added for each field in the Avro schema
 including any default values defined in the schema. `ActiveModel` validations
-are used to define validations on certain types of fields.
+are used to define validations on certain types of fields ([see below](#validations)).
 
 A model may be defined with both a key and a value schema:
 
@@ -88,6 +97,40 @@ constant:
 MyModel = Avromatic::Model.model(schema_name :my_model)
 ```
 
+#### Custom Types
+
+Custom types can be configured for fields of named types (record, enum, fixed).
+These customizations are registered on the `Avromatic` module. Once a custom type
+is registered, it is used for all models with a schema that references that type.
+
+```ruby
+Avromatic.register_type('com.example.my_string', MyString)
+```
+
+The full name of the type and an optional class may be specified. When a class is
+provided then values for attributes of that type are defined using the specified 
+class.
+
+If the provided class responds to the class methods `from_avro` and `to_avro`
+then those methods are used to convert values when assigning to the model and 
+before encoding using Avro respectively.
+
+`from_avro` and `to_avro` methods may be also be specified as Procs when 
+registering the type:
+
+```ruby
+Avromatic.register_type('com.example.updown_string') do |type|
+  type.from_avro = ->(value) { value.upcase }
+  type.to_avro = ->(value) { value.downcase }
+end
+```
+
+Nil handling is not required as the conversion methods are not be called if the
+inbound or outbound value is nil.
+
+If a custom type is registered for a record-type field, then any `to_avro` 
+method/Proc should return a Hash with string keys for encoding using Avro.
+
 #### Encode/Decode
 
 Models can be encoded using Avro leveraging a schema registry to encode a schema
@@ -97,7 +140,7 @@ id at the beginning of the value.
 model.avro_message_value
 ```
 
-If a model has a Avro schema for a key, then the key can also be encoded
+If a model has an Avro schema for a key, then the key can also be encoded
 prefixed with a schema id.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -102,9 +102,12 @@ MyModel = Avromatic::Model.model(schema_name :my_model)
 Custom types can be configured for fields of named types (record, enum, fixed).
 These customizations are registered on the `Avromatic` module. Once a custom type
 is registered, it is used for all models with a schema that references that type.
+It is recommended to register types within a block passed to `Avromatic.configure`:
 
 ```ruby
-Avromatic.register_type('com.example.my_string', MyString)
+Avromatic.configure do |config|
+  config.register_type('com.example.my_string', MyString)
+end
 ```
 
 The full name of the type and an optional class may be specified. When a class is
@@ -119,9 +122,11 @@ before encoding using Avro respectively.
 registering the type:
 
 ```ruby
-Avromatic.register_type('com.example.updown_string') do |type|
-  type.from_avro = ->(value) { value.upcase }
-  type.to_avro = ->(value) { value.downcase }
+Avromatic.configure do |config|
+  config.register_type('com.example.updown_string') do |type|
+    type.from_avro = ->(value) { value.upcase }
+    type.to_avro = ->(value) { value.downcase }
+  end
 end
 ```
 

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -5,10 +5,14 @@ require 'avro_turf/messaging'
 
 module Avromatic
   class << self
-    attr_accessor :schema_registry, :registry_url, :schema_store, :logger, :messaging
+    attr_accessor :schema_registry, :registry_url, :schema_store, :logger,
+                  :messaging, :type_registry
+
+    delegate :register_type, to: :type_registry
   end
 
   self.logger = Logger.new($stdout)
+  self.type_registry = Avromatic::Model::TypeRegistry.new
 
   def self.configure
     yield self

--- a/lib/avromatic/model.rb
+++ b/lib/avromatic/model.rb
@@ -1,5 +1,6 @@
 require 'avromatic/model/builder'
 require 'avromatic/model/decoder'
+require 'avromatic/model/type_registry'
 
 module Avromatic
   module Model

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -57,7 +57,7 @@ module Avromatic
                       avro_field_options(field))
 
             add_validation(field)
-            add_coder(field)
+            add_serializer(field)
           end
         end
 
@@ -132,7 +132,7 @@ module Avromatic
           options = {}
 
           custom_type = Avromatic.type_registry.fetch(field)
-          coercer = custom_type.coercer
+          coercer = custom_type.deserializer
           options[:coercer] = coercer if coercer
 
           if field.default
@@ -142,11 +142,11 @@ module Avromatic
           options
         end
 
-        def add_coder(field)
+        def add_serializer(field)
           custom_type = Avromatic.type_registry.fetch(field)
-          coder = custom_type.coder
+          serializer = custom_type.serializer
 
-          avro_coder[field.name.to_sym] = coder if coder
+          avro_serializer[field.name.to_sym] = serializer if serializer
         end
 
         def default_for(value)

--- a/lib/avromatic/model/configuration.rb
+++ b/lib/avromatic/model/configuration.rb
@@ -1,7 +1,7 @@
 module Avromatic
   module Model
 
-    # This class holds configuration for a model build from Avro schema(s).
+    # This class holds configuration for a model built from Avro schema(s).
     class Configuration
 
       attr_reader :avro_schema, :key_avro_schema
@@ -17,7 +17,6 @@ module Avromatic
       # @option options [String, Symbol] :value_schema_name
       # @option options [Avro::Schema] :key_schema
       # @option options [String, Symbol] :key_schema_name
-      # @option options [schema store] :schema_store
       def initialize(**options)
         @avro_schema = find_avro_schema(**options)
         raise ArgumentError.new('value_schema(_name) or schema(_name) must be specified') unless avro_schema

--- a/lib/avromatic/model/custom_type.rb
+++ b/lib/avromatic/model/custom_type.rb
@@ -1,0 +1,55 @@
+require 'avromatic/model/null_custom_type'
+
+module Avromatic
+  module Model
+
+    # Instances of this class contains the configuration for custom handling of
+    # a named type (record, enum, fixed).
+    class CustomType
+
+      attr_accessor :to_avro, :from_avro, :value_class
+
+      def initialize(value_class)
+        @value_class = value_class
+      end
+
+      # A coercer method is used when assigning to the model. It is used both when
+      # deserializing a model instance from Avro and when directly instantiating
+      # an instance. The coecer method must accept a single argument and return
+      # the value to store in the model for the attribute.
+      def coercer
+        proc = from_avro_proc
+        wrap_proc(proc) if proc
+      end
+
+      # A coder method is used when preparing attributes to be serialized using
+      # Avro. The coder method must accept a single argument of the model value
+      # for the attribute and return a value in a form that Avro can serialize
+      # for the attribute.
+      def coder
+        proc = to_avro_proc
+        wrap_proc(proc) if proc
+      end
+
+      private
+
+      def to_avro_proc
+        to_avro || value_class_method(:to_avro)
+      end
+
+      def from_avro_proc
+        from_avro || value_class_method(:from_avro)
+      end
+
+      def value_class_method(method_name)
+        value_class && value_class.respond_to?(method_name) &&
+          value_class.method(method_name).to_proc
+      end
+
+      # Wrap the supplied Proc to handle nil.
+      def wrap_proc(proc)
+        ->(value) { proc.call(value) if value }
+      end
+    end
+  end
+end

--- a/lib/avromatic/model/custom_type.rb
+++ b/lib/avromatic/model/custom_type.rb
@@ -13,20 +13,20 @@ module Avromatic
         @value_class = value_class
       end
 
-      # A coercer method is used when assigning to the model. It is used both when
+      # A deserializer method is used when assigning to the model. It is used both when
       # deserializing a model instance from Avro and when directly instantiating
-      # an instance. The coecer method must accept a single argument and return
+      # an instance. The deserializer method must accept a single argument and return
       # the value to store in the model for the attribute.
-      def coercer
+      def deserializer
         proc = from_avro_proc
         wrap_proc(proc) if proc
       end
 
-      # A coder method is used when preparing attributes to be serialized using
-      # Avro. The coder method must accept a single argument of the model value
+      # A serializer method is used when preparing attributes to be serialized using
+      # Avro. The serializer method must accept a single argument of the model value
       # for the attribute and return a value in a form that Avro can serialize
       # for the attribute.
-      def coder
+      def serializer
         proc = to_avro_proc
         wrap_proc(proc) if proc
       end

--- a/lib/avromatic/model/null_custom_type.rb
+++ b/lib/avromatic/model/null_custom_type.rb
@@ -8,11 +8,11 @@ module Avromatic
           nil
         end
 
-        def coercer
+        def deserializer
           nil
         end
 
-        def coder
+        def serializer
           nil
         end
       end

--- a/lib/avromatic/model/null_custom_type.rb
+++ b/lib/avromatic/model/null_custom_type.rb
@@ -1,0 +1,21 @@
+module Avromatic
+  module Model
+
+    # This module is used to implement the null object pattern for a CustomType.
+    module NullCustomType
+      class << self
+        def value_class
+          nil
+        end
+
+        def coercer
+          nil
+        end
+
+        def coder
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/avromatic/model/passthrough_coder.rb
+++ b/lib/avromatic/model/passthrough_coder.rb
@@ -1,0 +1,10 @@
+module Avromatic
+  module Model
+    # This trivial coder simply returns the value provided.
+    module PassthroughCoder
+      def self.call(value)
+        value
+      end
+    end
+  end
+end

--- a/lib/avromatic/model/passthrough_serializer.rb
+++ b/lib/avromatic/model/passthrough_serializer.rb
@@ -1,7 +1,7 @@
 module Avromatic
   module Model
-    # This trivial coder simply returns the value provided.
-    module PassthroughCoder
+    # This trivial serializer simply returns the value provided.
+    module PassthroughSerializer
       def self.call(value)
         value
       end

--- a/lib/avromatic/model/serialization.rb
+++ b/lib/avromatic/model/serialization.rb
@@ -1,4 +1,5 @@
 require 'avro_turf/messaging'
+require 'avromatic/model/passthrough_coder'
 
 module Avromatic
   module Model
@@ -32,6 +33,8 @@ module Avromatic
 
         private
 
+        delegate :avro_coder, to: :class
+
         def key_attributes_for_avro
           avro_hash(key_avro_field_names)
         end
@@ -41,7 +44,7 @@ module Avromatic
             result[key.to_s] = if value.is_a?(Avromatic::Model::Attributes)
                                  value.value_attributes_for_avro
                                else
-                                 value
+                                 avro_coder[key].call(value)
                                end
           end
         end
@@ -70,6 +73,13 @@ module Avromatic
         delegate :messaging, to: :Avromatic
 
         include Decode
+
+        # Store a hash of Procs by field name (as a symbol) to convert
+        # the value before Avro serialization.
+        # Returns the default PassthroughCoder if a key is not present.
+        def avro_coder
+          @avro_coder ||= Hash.new(PassthroughCoder)
+        end
       end
     end
   end

--- a/lib/avromatic/model/serialization.rb
+++ b/lib/avromatic/model/serialization.rb
@@ -1,5 +1,5 @@
 require 'avro_turf/messaging'
-require 'avromatic/model/passthrough_coder'
+require 'avromatic/model/passthrough_serializer'
 
 module Avromatic
   module Model
@@ -33,7 +33,7 @@ module Avromatic
 
         private
 
-        delegate :avro_coder, to: :class
+        delegate :avro_serializer, to: :class
 
         def key_attributes_for_avro
           avro_hash(key_avro_field_names)
@@ -44,7 +44,7 @@ module Avromatic
             result[key.to_s] = if value.is_a?(Avromatic::Model::Attributes)
                                  value.value_attributes_for_avro
                                else
-                                 avro_coder[key].call(value)
+                                 avro_serializer[key].call(value)
                                end
           end
         end
@@ -76,9 +76,9 @@ module Avromatic
 
         # Store a hash of Procs by field name (as a symbol) to convert
         # the value before Avro serialization.
-        # Returns the default PassthroughCoder if a key is not present.
-        def avro_coder
-          @avro_coder ||= Hash.new(PassthroughCoder)
+        # Returns the default PassthroughSerializer if a key is not present.
+        def avro_serializer
+          @avro_serializer ||= Hash.new(PassthroughSerializer)
         end
       end
     end

--- a/lib/avromatic/model/type_registry.rb
+++ b/lib/avromatic/model/type_registry.rb
@@ -1,0 +1,42 @@
+require 'avromatic/model/custom_type'
+
+module Avromatic
+  module Model
+    class TypeRegistry
+
+      delegate :clear, to: :custom_types
+
+      def initialize
+        @custom_types = {}
+      end
+
+      # @param fullname [String] The fullname of the Avro type.
+      # @param value_class [Class] Optional class to use for the attribute.
+      #   If unspecified then the default class for the Avro field is used.
+      # @block If a block is specified then the CustomType is yielded for
+      #   additional configuration.
+      def register_type(fullname, value_class = nil)
+        custom_types[fullname.to_s] = Avromatic::Model::CustomType.new(value_class).tap do |type|
+          yield(type) if block_given?
+        end
+      end
+
+      # @object [Avro::Schema] Custom type may be fetched based on a Avro field
+      #   or schema. If there is no custom type, then NullCustomType is returned.
+      def fetch(object)
+        field_type = object.is_a?(Avro::Schema::Field) ? object.type : object
+
+        if field_type.type_sym == :union
+          field_type = Avromatic::Model::Attributes.first_union_schema(field_type)
+        end
+
+        fullname = field_type.fullname if field_type.is_a?(Avro::Schema::NamedSchema)
+        custom_types.fetch(fullname, NullCustomType)
+      end
+
+      private
+
+      attr_reader :custom_types
+    end
+  end
+end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/spec/avro/dsl/test/named_type.rb
+++ b/spec/avro/dsl/test/named_type.rb
@@ -1,0 +1,8 @@
+namespace :test
+
+fixed :six, size: 6
+
+record :named_type  do
+  required :six_str, :six, default: ''.ljust(6)
+  optional :optional_six, :six
+end

--- a/spec/avro/dsl/test/nested_record.rb
+++ b/spec/avro/dsl/test/nested_record.rb
@@ -1,0 +1,10 @@
+namespace :test
+
+record :nested_record do
+  required :str, :string, default: 'A'
+
+  required :sub, :record do
+    required :str, :string, default: 'B'
+    required :i, :int, default: 0
+  end
+end

--- a/spec/avro/dsl/test/with_varchar.rb
+++ b/spec/avro/dsl/test/with_varchar.rb
@@ -1,0 +1,10 @@
+namespace :test
+
+record :varchar do
+  required :length, :int
+  required :data, :bytes
+end
+
+record :with_varchar do
+  required :str, :varchar
+end

--- a/spec/avro/schema/test/named_type.avsc
+++ b/spec/avro/schema/test/named_type.avsc
@@ -1,0 +1,25 @@
+{
+  "type": "record",
+  "name": "named_type",
+  "namespace": "test",
+  "fields": [
+    {
+      "name": "six_str",
+      "type": {
+        "name": "six",
+        "type": "fixed",
+        "namespace": "test",
+        "size": 6
+      },
+      "default": "      "
+    },
+    {
+      "name": "optional_six",
+      "type": [
+        "null",
+        "test.six"
+      ],
+      "default": null
+    }
+  ]
+}

--- a/spec/avro/schema/test/nested_record.avsc
+++ b/spec/avro/schema/test/nested_record.avsc
@@ -1,0 +1,32 @@
+{
+  "type": "record",
+  "name": "nested_record",
+  "namespace": "test",
+  "fields": [
+    {
+      "name": "str",
+      "type": "string",
+      "default": "A"
+    },
+    {
+      "name": "sub",
+      "type": {
+        "type": "record",
+        "name": "__nested_record_sub_record",
+        "namespace": "test",
+        "fields": [
+          {
+            "name": "str",
+            "type": "string",
+            "default": "B"
+          },
+          {
+            "name": "i",
+            "type": "int",
+            "default": 0
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/spec/avro/schema/test/with_varchar.avsc
+++ b/spec/avro/schema/test/with_varchar.avsc
@@ -1,0 +1,25 @@
+{
+  "type": "record",
+  "name": "with_varchar",
+  "namespace": "test",
+  "fields": [
+    {
+      "name": "str",
+      "type": {
+        "type": "record",
+        "name": "varchar",
+        "namespace": "test",
+        "fields": [
+          {
+            "name": "length",
+            "type": "int"
+          },
+          {
+            "name": "data",
+            "type": "bytes"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/spec/model/serialization_spec.rb
+++ b/spec/model/serialization_spec.rb
@@ -24,6 +24,19 @@ describe Avromatic::Model::Serialization do
       decoded = test_class.deserialize(message_value)
       expect(decoded).to eq(instance)
     end
+
+    context "with a nested record" do
+      let(:test_class) do
+        Avromatic::Model.model(value_schema_name: 'test.nested_record')
+      end
+      let(:values) { { str: 'a', sub: { str: 'b', i: 1 } } }
+
+      it "encodes the value for the model" do
+        message_value = instance.avro_message_value
+        decoded = test_class.deserialize(message_value)
+        expect(decoded).to eq(instance)
+      end
+    end
   end
 
   describe "#avro_message_key" do

--- a/spec/model/serialization_spec.rb
+++ b/spec/model/serialization_spec.rb
@@ -1,11 +1,14 @@
 require 'spec_helper'
 require 'webmock/rspec'
 require 'avro_turf/test/fake_schema_registry_server'
+require 'avro/builder'
 
 describe Avromatic::Model::Serialization do
   let(:registry_url) { 'http://registry.example.com' }
   let(:values) { { id: rand(99) } }
   let(:instance) { test_class.new(values) }
+  let(:avro_message_value) { instance.avro_message_value }
+  let(:avro_message_key) { instance.avro_message_key }
 
   before do
     Avromatic.registry_url = registry_url
@@ -71,7 +74,6 @@ describe Avromatic::Model::Serialization do
       Avromatic::Model.model(value_schema_name: 'test.encode_value')
     end
     let(:values) { { str1: 'a', str2: 'b' } }
-    let(:avro_message_value) { instance.avro_message_value }
 
     it "deserializes a model" do
       decoded = test_class.deserialize(avro_message_value)
@@ -85,11 +87,126 @@ describe Avromatic::Model::Serialization do
           key_schema_name: 'test.encode_key')
       end
       let(:values) { { id: rand(99), str1: 'a', str2: 'b' } }
-      let(:avro_message_key) { instance.avro_message_key }
 
       it "deserializes a model" do
         decoded = test_class.deserialize(avro_message_key, avro_message_value)
         expect(decoded).to eq(instance)
+      end
+    end
+  end
+
+  context "custom types" do
+    let(:schema_name) { 'test.named_type' }
+    let(:test_class) do
+      Avromatic::Model.model(schema_name: schema_name)
+    end
+    let(:values) { { six_str: 'fOObAR' } }
+
+    context "with a value class" do
+      let(:value_class) do
+        Class.new do
+          attr_reader :value
+
+          def initialize(value)
+            @value = value
+          end
+
+          def self.from_avro(value)
+            new(value.downcase)
+          end
+
+          def self.to_avro(value)
+            value.value.capitalize
+          end
+        end
+      end
+
+      before do
+        Avromatic.register_type('test.six', value_class)
+      end
+
+      it "stores the attribute in the model class" do
+        expect(instance.six_str).to be_a(value_class)
+      end
+
+      it "converts when assigning to the model" do
+        expect(instance.six_str.value).to eq('foobar')
+      end
+
+      it "converts when encoding the value" do
+        decoded = Avromatic.messaging.decode(avro_message_value, schema_name: schema_name)
+        expect(decoded['six_str']).to eq('Foobar')
+      end
+    end
+
+    context "without a value class" do
+      before do
+        Avromatic.register_type('test.six') do |type|
+          type.from_avro = ->(value) { value.downcase }
+          type.to_avro = ->(value) { value.capitalize }
+        end
+      end
+
+      it "converts when assigning to the model" do
+        expect(instance.six_str).to eq('foobar')
+      end
+
+      it "converts when encoding the value" do
+        decoded = Avromatic.messaging.decode(avro_message_value, schema_name: schema_name)
+        expect(decoded['six_str']).to eq('Foobar')
+      end
+    end
+
+    context "custom type in a union" do
+      let(:values) { { optional_six: 'fOObAR' } }
+
+      before do
+        Avromatic.register_type('test.six') do |type|
+          type.from_avro = ->(value) { value.downcase }
+          type.to_avro = ->(value) { value.capitalize }
+        end
+      end
+
+      it "converts when assigning to the model" do
+        expect(instance.optional_six).to eq('foobar')
+      end
+
+      it "converts when encoding the value" do
+        decoded = Avromatic.messaging.decode(avro_message_value, schema_name: schema_name)
+        expect(decoded['optional_six']).to eq('Foobar')
+      end
+    end
+
+    context "custom type for record" do
+      let(:schema_name) { 'test.with_varchar' }
+      let(:test_class) do
+        Avromatic::Model.model(schema_name: schema_name)
+      end
+      let(:values) { { str: 'test' } }
+
+      before do
+        Avromatic.register_type('test.varchar', String) do |type|
+          type.from_avro = ->(value) do
+            value.is_a?(String) ? value : value['data']
+          end
+          type.to_avro = ->(value) do
+            { 'data' => value, 'length' => value.size }
+          end
+        end
+      end
+
+      it "stores the attribute" do
+        expect(instance.str).to eq('test')
+      end
+
+      it "converts when encoding the value" do
+        decoded = Avromatic.messaging.decode(avro_message_value, schema_name: schema_name)
+        expect(decoded['str']).to eq({ 'length' => 4, 'data' => 'test' })
+      end
+
+      it "converts when assigning to the model" do
+        decoded = test_class.deserialize(avro_message_value)
+        expect(decoded.str).to eq('test')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,5 +11,6 @@ RSpec.configure do |config|
     Avromatic.registry_url = 'http://registry.example.com'
     Avromatic.schema_store = AvroTurf::SchemaStore.new(path: 'spec/avro/schema')
     Avromatic.build_messaging!
+    Avromatic.type_registry.clear
   end
 end


### PR DESCRIPTION
This change allows custom types to be registered for named types (record, enum, fixed). As part of the configuration for a custom type, a class can be specified for attribute values and methods for conversion to and from Avro.

Further details in the README.

Prime: @jturkel 