### PR TITLE
Fix serialization of array or map of nested models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## v0.6.1
+- Fix serialization of array and map types that contain nested models.
+
 ## v0.6.0
 - Require `avro_turf` v0.7.0 or later.
 

--- a/avromatic.gemspec
+++ b/avromatic.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock'
-  spec.add_development_dependency 'avro-builder', '>= 0.3.2'
+  spec.add_development_dependency 'avro-builder', '>= 0.7.0'
   # For FakeSchemaRegistryServer
   spec.add_development_dependency 'sinatra'
   spec.add_development_dependency 'salsify_rubocop', '~> 0.40.1'

--- a/lib/avromatic/model/raw_serialization.rb
+++ b/lib/avromatic/model/raw_serialization.rb
@@ -23,8 +23,6 @@ module Avromatic
           avro_raw_encode(key_attributes_for_avro, :key)
         end
 
-        protected
-
         def value_attributes_for_avro
           avro_hash(value_avro_field_names)
         end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.6.1'.freeze
 end


### PR DESCRIPTION
New tests verify that models of these forms can be initialized using a hash, and round-trip correctly through serialization.

Prime: @jturkel 