### PR TITLE
Raise an error for non-record Avro types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # avromatic changelog
 
+## v0.7.1
+- Raise a more descriptive error when attempting to generate a model for a
+  non-record Avro type.
+
 ## v0.7.0
 - Add RSpec `FakeSchemaRegistryServer` test helper.
 

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -51,6 +51,10 @@ module Avromatic
         end
 
         def define_avro_attributes(schema)
+          if schema.type_sym != :record
+            raise "Unsupported schema type '#{schema.type_sym}', only 'record' schemas are supported."
+          end
+
           schema.fields.each do |field|
             field_class = avro_field_class(field.type)
 

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.7.0'.freeze
+  VERSION = '0.7.1'.freeze
 end

--- a/spec/avro/dsl/test/real_union.rb
+++ b/spec/avro/dsl/test/real_union.rb
@@ -1,0 +1,14 @@
+namespace :test
+
+record :foo do
+  required :foo_message, :string
+end
+
+record :bar do
+  required :bar_message, :string
+end
+
+record :real_union do
+  required :header, :string
+  required :message, :union, types: [:foo, :bar]
+end

--- a/spec/avro/dsl/test/value.rb
+++ b/spec/avro/dsl/test/value.rb
@@ -1,5 +1,4 @@
-record :value do
-  namespace :test
+record :value, namespace: :test do
   required :action, :enum, symbols: %i(CREATE UPDATE DESTROY)
   required :id, :long
 end

--- a/spec/avro/schema/test/real_union.avsc
+++ b/spec/avro/schema/test/real_union.avsc
@@ -1,0 +1,38 @@
+{
+  "type": "record",
+  "name": "real_union",
+  "namespace": "test",
+  "fields": [
+    {
+      "name": "header",
+      "type": "string"
+    },
+    {
+      "name": "message",
+      "type": [
+        {
+          "type": "record",
+          "name": "foo",
+          "namespace": "test",
+          "fields": [
+            {
+              "name": "foo_message",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "type": "record",
+          "name": "bar",
+          "namespace": "test",
+          "fields": [
+            {
+              "name": "bar_message",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -115,6 +115,40 @@ describe Avromatic::Model::Builder do
       it_behaves_like 'a generated model'
     end
 
+    context "unsupported union" do
+      let(:schema_name) { 'test.real_union' }
+
+      it "raises an error" do
+        expect { test_class }
+          .to raise_error(/Only the union of null with one other type is supported/)
+      end
+    end
+
+    context "top-level union" do
+      let(:schema) do
+        [
+          {
+            type: :record,
+            name: :foo,
+            fields: [{ name: :foo_message, type: :string }]
+          },
+          {
+            type: :record,
+            name: :boo,
+            fields: [{ name: :bar_message, type: :string }]
+          }
+        ].to_json
+      end
+      let(:test_class) do
+        Avromatic::Model.model(schema: Avro::Schema.parse(schema))
+      end
+
+      it "raises an error" do
+        expect { test_class }
+          .to raise_error("Unsupported schema type 'union', only 'record' schemas are supported.")
+      end
+    end
+
     context "with a key and value" do
       let(:schema_name) { 'test.value' }
       let(:key_schema_name) { 'test.key' }


### PR DESCRIPTION
This change adds test cases and a more descriptive error when the top-level type used to define a model is not an Avro record.

This provides better feedback for the schema in Issue #16.

Prime: @jturkel 