### PR TITLE
Fix the handling of nested, complex types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.9.0 (unreleased)
 - Add support for more than one non-null type in a union.
+- Fix the serialization of nested complex types.
 
 ## v0.8.0
 - Add support for logical types. Currently this requires using the

--- a/lib/avromatic/model/attribute/record.rb
+++ b/lib/avromatic/model/attribute/record.rb
@@ -19,7 +19,7 @@ module Avromatic
         end
 
         def value_coerced?(value)
-          value.kind_of?(primitive)
+          value.is_a?(primitive)
         end
       end
     end

--- a/lib/avromatic/model/attribute/record.rb
+++ b/lib/avromatic/model/attribute/record.rb
@@ -1,0 +1,27 @@
+module Avromatic
+  module Model
+    module Attribute
+
+      # This subclass of Virtus::Attribute is defined to ensure that Avromatic
+      # generated models (identified by their inclusion of
+      # Avromatic::Model::Attributes) are always coerced by identifying an
+      # instance of the model or creating a new one.
+      # This is required to coerce models correctly with nested complex types
+      # with Virtus.
+      class Record < Virtus::Attribute
+        primitive Avromatic::Model::Attributes
+
+        def coerce(value)
+          return value if value.nil? || value_coerced?(value)
+
+          coerced = primitive.new(value)
+          coerced if coerced.valid?
+        end
+
+        def value_coerced?(value)
+          value.kind_of?(primitive)
+        end
+      end
+    end
+  end
+end

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -128,7 +128,9 @@ module Avromatic
           when :record
             # TODO: This should add the generated model to a module.
             # A hash of generated models should be kept by name for reuse.
-            Avromatic::Model.model(schema: field_type)
+            Avromatic::Model.model(schema: field_type).tap do |record_class|
+              Axiom::Types::Object.new { primitive(record_class) }
+            end
           else
             raise "Unsupported type #{field_type}"
           end

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -129,6 +129,9 @@ module Avromatic
             # TODO: This should add the generated model to a module.
             # A hash of generated models should be kept by name for reuse.
             Avromatic::Model.model(schema: field_type).tap do |record_class|
+              # Register the generated model with Axiom to prevent it being
+              # treated as a BasicObject.
+              # See https://github.com/solnic/virtus/issues/284#issuecomment-56405137
               Axiom::Types::Object.new { primitive(record_class) }
             end
           else

--- a/lib/avromatic/model/builder.rb
+++ b/lib/avromatic/model/builder.rb
@@ -6,6 +6,7 @@ require 'avromatic/model/value_object'
 require 'avromatic/model/configurable'
 require 'avromatic/model/attribute/union'
 require 'avromatic/model/attributes'
+require 'avromatic/model/attribute/record'
 require 'avromatic/model/raw_serialization'
 require 'avromatic/model/messaging_serialization'
 

--- a/lib/avromatic/model/raw_serialization.rb
+++ b/lib/avromatic/model/raw_serialization.rb
@@ -16,7 +16,7 @@ module Avromatic
         private :avro_serializer, :datum_writer, :datum_reader
 
         module ClassMethods
-          def recursive_serialize(value, key = nil)
+          def recursive_serialize(value, attribute_name = nil)
             if value.is_a?(Avromatic::Model::Attributes)
               value.value_attributes_for_avro
             elsif value.is_a?(Array)
@@ -26,7 +26,7 @@ module Avromatic
                 hash[k] = recursive_serialize(v)
               end
             else
-              avro_serializer[key].call(value)
+              avro_serializer[attribute_name].call(value)
             end
           end
         end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.9.0.rc0'.freeze
+  VERSION = '0.9.0.rc1'.freeze
 end

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -359,7 +359,6 @@ describe Avromatic::Model::Builder do
       before do
         Avromatic.register_type('handshake', String) do |type|
           type.from_avro = ->(value) { value.downcase }
-          # type.to_avro = ->(value) { value.upcase }
         end
       end
 

--- a/spec/avromatic/model/raw_serialization_spec.rb
+++ b/spec/avromatic/model/raw_serialization_spec.rb
@@ -211,13 +211,12 @@ describe Avromatic::Model::RawSerialization do
       let(:values) do
         { union_map: {
           'str' => { s: 'A' },
-          'int' => { i: 'C' }
+          'int' => { i: 22 }
         } }
       end
       let(:decoded) { test_class.avro_raw_decode(value: avro_raw_value) }
 
       it "encodes and decodes the model" do
-        puts instance.inspect
         expect(instance).to eq(decoded)
       end
     end

--- a/spec/avromatic/model/raw_serialization_spec.rb
+++ b/spec/avromatic/model/raw_serialization_spec.rb
@@ -180,7 +180,7 @@ describe Avromatic::Model::RawSerialization do
         Avromatic::Model.model(schema: schema)
       end
       let(:values) do
-        { unions: [{ s: 'A'}, { i: 1 }, { s: 'C' }] }
+        { unions: [{ s: 'A' }, { i: 1 }, { s: 'C' }] }
       end
       let(:decoded) { test_class.avro_raw_decode(value: avro_raw_value) }
 

--- a/spec/avromatic/model/raw_serialization_spec.rb
+++ b/spec/avromatic/model/raw_serialization_spec.rb
@@ -131,8 +131,96 @@ describe Avromatic::Model::RawSerialization do
   end
 
   it_behaves_like "logical type encoding and decoding" do
-    let(:encoded_value) { instance.avro_raw_value }
-    let(:decoded) { test_class.avro_raw_decode(value: encoded_value) }
+    let(:decoded) { test_class.avro_raw_decode(value: avro_raw_value) }
+  end
+
+  context "nested serialization" do
+    context "array of array of records" do
+      let(:schema) do
+        Avro::Builder.build_schema do
+          record :int_rec do
+            required :i, :int
+          end
+
+          record :transform do
+            required :matrix, :array, items: array(:int_rec)
+          end
+        end
+      end
+      let(:test_class) do
+        Avromatic::Model.model(schema: schema)
+      end
+      let(:values) do
+        { matrix: [[{ i: 1 }, { i: 2 }], [{ i: 3 }, { i: 4 }]] }
+      end
+      let(:decoded) { test_class.avro_raw_decode(value: avro_raw_value) }
+
+      it "encodes and decodes the model" do
+        expect(instance).to eq(decoded)
+      end
+    end
+
+    context "array of unions" do
+      let(:schema) do
+        Avro::Builder.build_schema do
+          record :str_rec do
+            required :s, :string
+          end
+
+          record :int_rec do
+            required :i, :int
+          end
+
+          record :mgmt do
+            required :unions, :array, items: union(:str_rec, :int_rec)
+          end
+        end
+      end
+      let(:test_class) do
+        Avromatic::Model.model(schema: schema)
+      end
+      let(:values) do
+        { unions: [{ s: 'A'}, { i: 1 }, { s: 'C' }] }
+      end
+      let(:decoded) { test_class.avro_raw_decode(value: avro_raw_value) }
+
+      it "encodes and decodes the model" do
+        expect(instance).to eq(decoded)
+      end
+    end
+
+    context "map of unions" do
+      let(:schema) do
+        Avro::Builder.build_schema do
+          record :str_rec do
+            required :s, :string
+          end
+
+          record :int_rec do
+            required :i, :int
+          end
+
+          record :mgmt do
+            required :union_map, :map, values: union(:str_rec, :int_rec)
+          end
+        end
+      end
+      let(:test_class) do
+        Avromatic::Model.model(schema: schema)
+      end
+      let(:values) do
+        { union_map: {
+          'str' => { s: 'A' },
+          'int' => { i: 'C' }
+        } }
+      end
+      let(:decoded) { test_class.avro_raw_decode(value: avro_raw_value) }
+
+      it "encodes and decodes the model" do
+        puts instance.inspect
+        expect(instance).to eq(decoded)
+      end
+    end
   end
 
   context "custom types" do


### PR DESCRIPTION
There are two basic issues addressed here:
- the serialization of arrays/maps of unions
- the coercion of records within other complex types

The latter issue seems to be a problem with Virtus. An array of generated models is coerced correctly, but an array of arrays of generated models is not coerced (for example). 

To workaround this issue a similar solution to that used for union support was implemented. Each generated model is registered with axiom and there is a new `Virtus::Attribute`subclass that ensures generated models are coerced by checking for a model instance or creating and validating a new one.

The plan once again is to create a pre-release with these changes for further testing.

Prime: @jturkel 