### PR TITLE
WIP: Reuse generated models

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,6 @@ inherit_gem:
 AllCops:
   TargetRubyVersion: 2.2
 
+Style/MultilineBlockChain:
+  Enabled: false
+

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Or install it yourself as:
   `Avro::Schema` objects. See [Models](#models).
 * **module**: A module that is used to collect the generated models that are
   embedded within top-level models. By default a new, anonymous module is used.
+* **strip_namespace_prefix**: A string or regexp that should be removed from the
+  full name of an embedded model when it is added to the module of generated
+  models. For example, if your namespace begins with `com.my_company` you may
+  want to remove that from the module namespace.
   
 #### Using a Schema Registry/Messaging API
  
@@ -110,6 +114,11 @@ constant:
 ```ruby
 MyModel = Avromatic::Model.model(schema_name :my_model)
 ```
+
+#### Embedded Models
+
+TODO Describe handling of embeded models and how they are namespaced and stored
+in a module.
 
 #### Custom Types
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Or install it yourself as:
   returns an `Avro::Schema` object. An `AvroTurf::SchemaStore` can be used.
   The `schema_store` is unnecessary if models are generated directly from 
   `Avro::Schema` objects. See [Models](#models).
+* **module**: A module that is used to collect the generated models that are
+  embedded within top-level models. By default a new, anonymous module is used.
   
 #### Using a Schema Registry/Messaging API
  

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -6,11 +6,12 @@ require 'avro_turf/messaging'
 module Avromatic
   class << self
     attr_accessor :schema_registry, :registry_url, :schema_store, :logger,
-                  :messaging, :type_registry
+                  :messaging, :type_registry, :module, :strip_namespace_prefix
 
     delegate :register_type, to: :type_registry
   end
 
+  self.module = Module.new
   self.logger = Logger.new($stdout)
   self.type_registry = Avromatic::Model::TypeRegistry.new
 

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -63,6 +63,8 @@ module Avromatic
                       field_class,
                       avro_field_options(field, field_class))
 
+            add_model(field.name, field_class) if field.type.type_sym == :record
+
             add_validation(field)
             add_serializer(field, field_class)
           end
@@ -126,14 +128,7 @@ module Avromatic
           when :union
             union_field_class(field_type)
           when :record
-            # TODO: This should add the generated model to a module.
-            # A hash of generated models should be kept by name for reuse.
-            Avromatic::Model.model(schema: field_type).tap do |record_class|
-              # Register the generated model with Axiom to prevent it being
-              # treated as a BasicObject.
-              # See https://github.com/solnic/virtus/issues/284#issuecomment-56405137
-              Axiom::Types::Object.new { primitive(record_class) }
-            end
+            build_model(field_type)
           else
             raise "Unsupported type #{field_type}"
           end

--- a/lib/avromatic/model/builder.rb
+++ b/lib/avromatic/model/builder.rb
@@ -4,6 +4,7 @@ require 'active_model'
 require 'avromatic/model/configuration'
 require 'avromatic/model/value_object'
 require 'avromatic/model/configurable'
+require 'avromatic/model/models'
 require 'avromatic/model/attribute/union'
 require 'avromatic/model/attributes'
 require 'avromatic/model/attribute/record'
@@ -42,6 +43,7 @@ module Avromatic
           ActiveModel::Validations,
           Virtus.value_object,
           Avromatic::Model::Configurable,
+          Avromatic::Model::Models,
           Avromatic::Model::Attributes,
           Avromatic::Model::ValueObject,
           Avromatic::Model::RawSerialization,

--- a/lib/avromatic/model/configurable.rb
+++ b/lib/avromatic/model/configurable.rb
@@ -26,6 +26,14 @@ module Avromatic
           @key_avro_fields_by_name ||= mapped_by_name(key_avro_schema)
         end
 
+        def module
+          config.module || Avromatic.module
+        end
+
+        def strip_namespace_prefix
+          config.strip_namespace_prefix || Avromatic.strip_namespace_prefix
+        end
+
         private
 
         def mapped_by_name(schema)

--- a/lib/avromatic/model/configuration.rb
+++ b/lib/avromatic/model/configuration.rb
@@ -4,7 +4,7 @@ module Avromatic
     # This class holds configuration for a model built from Avro schema(s).
     class Configuration
 
-      attr_reader :avro_schema, :key_avro_schema
+      attr_reader :avro_schema, :key_avro_schema, :module, :strip_namespace_prefix
       delegate :schema_store, to: Avromatic
 
       # Either schema(_name) or value_schema(_name), but not both, must be
@@ -17,10 +17,14 @@ module Avromatic
       # @option options [String, Symbol] :value_schema_name
       # @option options [Avro::Schema] :key_schema
       # @option options [String, Symbol] :key_schema_name
+      # @option options [Module] :module
+      # @option options [String, Regexp] :strip_namespace_prefix
       def initialize(**options)
         @avro_schema = find_avro_schema(**options)
         raise ArgumentError.new('value_schema(_name) or schema(_name) must be specified') unless avro_schema
         @key_avro_schema = find_schema_by_option(:key_schema, **options)
+        @module = options[:module]
+        @strip_namespace_prefix = options[:@strip_namespace_prefix]
       end
 
       alias_method :value_avro_schema, :avro_schema
@@ -39,7 +43,6 @@ module Avromatic
         schema_name_option = :"#{option_name}_name"
         options[option_name] ||
           (options[schema_name_option] && schema_store.find(options[schema_name_option]))
-
       end
     end
   end

--- a/lib/avromatic/model/models.rb
+++ b/lib/avromatic/model/models.rb
@@ -1,0 +1,71 @@
+require 'active_support/inflector/methods'
+
+module Avromatic
+  module Model
+    module Models
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        # Hash of generated models by field name
+        def models
+          @models ||= {}
+        end
+
+        def add_model(field_name, model)
+          models[field_name.to_sym] = model
+        end
+
+        def build_model(schema)
+          name_parts = get_name_parts(schema)
+          model_name = name_parts.pop
+
+          parent_module = define_modules(name_parts)
+
+          module_fetch(parent_module, model_name) do
+            Avromatic::Model.model(schema: schema,
+                                   module: self.module)
+          end.tap do |model|
+            # Register the generated model with Axiom to prevent it being
+            # treated as a BasicObject.
+            # See https://github.com/solnic/virtus/issues/284#issuecomment-56405137
+            Axiom::Types::Object.new { primitive(model) }
+          end
+        end
+
+        private
+
+        def define_modules(name_parts)
+          parent_module = self.module
+          name_parts.each do |part|
+            parent_module = module_fetch(parent_module, part) { Module.new }
+          end
+          parent_module
+        end
+
+        def module_fetch(mod, name)
+          if mod.const_defined?(name, false)
+            mod.const_get(name)
+          else
+            mod.const_set(name, yield)
+          end
+        end
+
+        def get_name_parts(schema)
+          name = schema.fullname
+          prefix = strip_namespace_prefix
+          if prefix
+            if prefix.is_a?(String)
+              name = name[prefix.length..-1] if name.starts_with?(prefix)
+            elsif prefix.is_a?(Regexp)
+              name = name.sub(prefix, '')
+            else
+              raise "unsupported strip_namespace_prefix value: #{prefix}"
+            end
+          end
+
+          name.split('.').reject(&:blank?).map(&:classify)
+        end
+      end
+    end
+  end
+end

--- a/lib/avromatic/model/models.rb
+++ b/lib/avromatic/model/models.rb
@@ -63,7 +63,7 @@ module Avromatic
             end
           end
 
-          name.split('.').reject(&:blank?).map(&:classify)
+          name.split('.').reject(&:blank?).map(&:camelize)
         end
       end
     end


### PR DESCRIPTION
This change adds support for reusing and directly referencing embedded models.

The `Avromatic` module can be configured with a *module* that is used to collect references to embedded models. These models are stored under a module namespace that is generated based on their schema namespace. There is also a *strip_namespace_prefix* option that can be configured to remove a prefix from the schema namespace before generating modules for namespacing.

If a module is not configured, then a new anonymous module is used.

The *module* and *strip_namespace_prefix* option can both be overridden when generating a model, otherwise generated models inherit from the `Avromatic` module.

Additionally, embedded models are available on a model via a `models` hash that is keyed by the field name.

Prime: @jturkel -- looking for high-level feedback on the form factor, API, and general approach.

Needs additional documentation and specs.