### PR TITLE
Reuse nested models

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,6 @@ inherit_gem:
 AllCops:
   TargetRubyVersion: 2.2
 
+Style/MultilineBlockChain:
+  Enabled: false
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # avromatic changelog
 
 ## v0.9.0 (unreleased)
-- Add support for more than one non-null type in a union.
+- Experimental: Add support for more than one non-null type in a union.
+- Allow nested models to be referenced and reused.
 - Fix the serialization of nested complex types.
 
 ## v0.8.0

--- a/README.md
+++ b/README.md
@@ -119,11 +119,15 @@ Avromatic contains experimental support for unions containing more than one
 non-null member type. This feature is experimental because Virtus attributes
 may attempt to coerce between types too aggressively.
 
+For now, if a union contains [nested models](#nested-models) then it is
+recommended that you assign model instances.
+
+Some combination of the ordering of member types in the union and relying on
+model validation may be required so that the correct member is selected,
+especially when deserializing from Avro.
+
 In the future, the type coercion used in the gem will be replaced to better
 support the union use case.
-
-For now, if a union contains nested models then it is recommended that you
-assign instances
 
 #### Nested Models
 
@@ -145,6 +149,8 @@ The `ModelRegistry` can be customized to remove a namespace prefix:
 Avromatic.nested_models =
   Avromatic::ModelRegistry.new(remove_namespace_prefix: 'com.my_company'
 ```
+
+The `:remove_namespace_prefix` value can be a string or a regexp.
 
 By default, top-level generated models reuse `Avromatic.nested_models`. This
 allows nested models to be shared across different generated models.
@@ -169,6 +175,9 @@ class UsefulSubrecord
 end
 Avromatic.nested_models.register(UsefulSubrecord)
 ```
+
+With Rails, it may be necessary to perform this explicit registration in an
+initializer so that lazy class loading works correctly in development.
 
 #### Custom Types
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ Or install it yourself as:
   returns an `Avro::Schema` object. An `AvroTurf::SchemaStore` can be used.
   The `schema_store` is unnecessary if models are generated directly from 
   `Avro::Schema` objects. See [Models](#models).
-  
+* **nested_models**: An optional [ModelRegistry](https://github.com/salsify/avromatic/blob/master/lib/avromatic/model_registry.rb)
+  that is used to store, by full schema name, the generated models that are
+  embedded within top-level models. By default a new `Avromatic::ModelRegistry`
+  is created.
+
 #### Using a Schema Registry/Messaging API
  
 The configuration options below are required when using a schema registry 
@@ -107,6 +111,63 @@ constant:
 
 ```ruby
 MyModel = Avromatic::Model.model(schema_name :my_model)
+```
+
+#### Experimental: Union Support
+
+Avromatic contains experimental support for unions containing more than one
+non-null member type. This feature is experimental because Virtus attributes
+may attempt to coerce between types too aggressively.
+
+In the future, the type coercion used in the gem will be replaced to better
+support the union use case.
+
+For now, if a union contains nested models then it is recommended that you
+assign instances
+
+#### Nested Models
+
+Nested models are models that are embedded within top-level models generated
+using Avromatic. Normally these nested models are automatically generated.
+
+By default, nested models are stored in `Avromatic.nested_models`. This is an
+`Avromatic::ModelRegistry` instance that provides access to previously generated
+nested models by the full name of their Avro schema.
+
+```ruby
+Avromatic.nested_models['com.my_company.test.example']
+#=> <model class>
+```
+
+The `ModelRegistry` can be customized to remove a namespace prefix:
+
+```ruby
+Avromatic.nested_models =
+  Avromatic::ModelRegistry.new(remove_namespace_prefix: 'com.my_company'
+```
+
+By default, top-level generated models reuse `Avromatic.nested_models`. This
+allows nested models to be shared across different generated models.
+A `:nested_models` option can be specified when generating a model. This allows
+the reuse of nested models to be scoped:
+
+```ruby
+Avromatic::Model.model(schema_name, :my_model
+                       nested_models: ModelRegistry.new)
+```
+
+It is also possible to explicitly generate a nested model that should be reused
+and add it to the registry. This is useful when the nested model is extended:
+
+```ruby
+class UsefulSubrecord
+  include Avromatic::Model.build(schema_name: 'useful_subrecord')
+
+  def do_something_custom
+    ...
+  end
+end
+Avromatic.nested_models.register(UsefulSubrecord)
 ```
 
 #### Custom Types

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -1,16 +1,18 @@
 require 'avromatic/version'
 require 'avromatic/model'
+require 'avromatic/model_registry'
 require 'avro_turf'
 require 'avro_turf/messaging'
 
 module Avromatic
   class << self
     attr_accessor :schema_registry, :registry_url, :schema_store, :logger,
-                  :messaging, :type_registry
+                  :messaging, :type_registry, :nested_models
 
     delegate :register_type, to: :type_registry
   end
 
+  self.nested_models = ModelRegistry.new
   self.logger = Logger.new($stdout)
   self.type_registry = Avromatic::Model::TypeRegistry.new
 

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -126,14 +126,7 @@ module Avromatic
           when :union
             union_field_class(field_type)
           when :record
-            # TODO: This should add the generated model to a module.
-            # A hash of generated models should be kept by name for reuse.
-            Avromatic::Model.model(schema: field_type).tap do |record_class|
-              # Register the generated model with Axiom to prevent it being
-              # treated as a BasicObject.
-              # See https://github.com/solnic/virtus/issues/284#issuecomment-56405137
-              Axiom::Types::Object.new { primitive(record_class) }
-            end
+            build_nested_model(field_type)
           else
             raise "Unsupported type #{field_type}"
           end

--- a/lib/avromatic/model/builder.rb
+++ b/lib/avromatic/model/builder.rb
@@ -4,6 +4,7 @@ require 'active_model'
 require 'avromatic/model/configuration'
 require 'avromatic/model/value_object'
 require 'avromatic/model/configurable'
+require 'avromatic/model/nested_models'
 require 'avromatic/model/attribute/union'
 require 'avromatic/model/attributes'
 require 'avromatic/model/attribute/record'
@@ -42,6 +43,7 @@ module Avromatic
           ActiveModel::Validations,
           Virtus.value_object,
           Avromatic::Model::Configurable,
+          Avromatic::Model::NestedModels,
           Avromatic::Model::Attributes,
           Avromatic::Model::ValueObject,
           Avromatic::Model::RawSerialization,

--- a/lib/avromatic/model/configurable.rb
+++ b/lib/avromatic/model/configurable.rb
@@ -26,6 +26,10 @@ module Avromatic
           @key_avro_fields_by_name ||= mapped_by_name(key_avro_schema)
         end
 
+        def nested_models
+          config.nested_models || Avromatic.nested_models
+        end
+
         private
 
         def mapped_by_name(schema)

--- a/lib/avromatic/model/configuration.rb
+++ b/lib/avromatic/model/configuration.rb
@@ -4,7 +4,7 @@ module Avromatic
     # This class holds configuration for a model built from Avro schema(s).
     class Configuration
 
-      attr_reader :avro_schema, :key_avro_schema
+      attr_reader :avro_schema, :key_avro_schema, :nested_models
       delegate :schema_store, to: Avromatic
 
       # Either schema(_name) or value_schema(_name), but not both, must be
@@ -17,10 +17,12 @@ module Avromatic
       # @option options [String, Symbol] :value_schema_name
       # @option options [Avro::Schema] :key_schema
       # @option options [String, Symbol] :key_schema_name
+      # @option options [Hash] :nested_models
       def initialize(**options)
         @avro_schema = find_avro_schema(**options)
         raise ArgumentError.new('value_schema(_name) or schema(_name) must be specified') unless avro_schema
         @key_avro_schema = find_schema_by_option(:key_schema, **options)
+        @nested_models = options[:nested_models]
       end
 
       alias_method :value_avro_schema, :avro_schema
@@ -39,7 +41,6 @@ module Avromatic
         schema_name_option = :"#{option_name}_name"
         options[option_name] ||
           (options[schema_name_option] && schema_store.find(options[schema_name_option]))
-
       end
     end
   end

--- a/lib/avromatic/model/configuration.rb
+++ b/lib/avromatic/model/configuration.rb
@@ -17,7 +17,7 @@ module Avromatic
       # @option options [String, Symbol] :value_schema_name
       # @option options [Avro::Schema] :key_schema
       # @option options [String, Symbol] :key_schema_name
-      # @option options [Hash] :nested_models
+      # @option options [Avromatic::ModelRegistry] :nested_models
       def initialize(**options)
         @avro_schema = find_avro_schema(**options)
         raise ArgumentError.new('value_schema(_name) or schema(_name) must be specified') unless avro_schema

--- a/lib/avromatic/model/nested_models.rb
+++ b/lib/avromatic/model/nested_models.rb
@@ -11,11 +11,14 @@ module Avromatic
         def build_nested_model(schema)
           fullname = schema.fullname
 
-          if nested_models.model?(fullname)
+          if nested_models.registered?(fullname)
             nested_models[fullname]
           else
             nested_model = Avromatic::Model.model(schema: schema,
                                                   nested_models: nested_models)
+            # Register the generated model with Axiom to prevent it being
+            # treated as a BasicObject.
+            # See https://github.com/solnic/virtus/issues/284#issuecomment-56405137
             Axiom::Types::Object.new { primitive(nested_model) }
             nested_models.register(nested_model)
           end

--- a/lib/avromatic/model/nested_models.rb
+++ b/lib/avromatic/model/nested_models.rb
@@ -1,0 +1,26 @@
+require 'active_support/inflector/methods'
+
+module Avromatic
+  module Model
+    # This module handles integration with the ModelRegistry and support
+    # for nested model reuse.
+    module NestedModels
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        def build_nested_model(schema)
+          fullname = schema.fullname
+
+          if nested_models.model?(fullname)
+            nested_models[fullname]
+          else
+            nested_model = Avromatic::Model.model(schema: schema,
+                                                  nested_models: nested_models)
+            Axiom::Types::Object.new { primitive(nested_model) }
+            nested_models.register(nested_model)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/avromatic/model/value_object.rb
+++ b/lib/avromatic/model/value_object.rb
@@ -1,5 +1,6 @@
 module Avromatic
   module Model
+    extend ActiveSupport::Concern
 
     # This module is used to override the comparisons defined by
     # Virtus::Equalizer which is pulled in by Virtus::ValueObject.

--- a/lib/avromatic/model/value_object.rb
+++ b/lib/avromatic/model/value_object.rb
@@ -1,7 +1,5 @@
 module Avromatic
   module Model
-    extend ActiveSupport::Concern
-
     # This module is used to override the comparisons defined by
     # Virtus::Equalizer which is pulled in by Virtus::ValueObject.
     module ValueObject

--- a/lib/avromatic/model_registry.rb
+++ b/lib/avromatic/model_registry.rb
@@ -1,0 +1,43 @@
+module Avromatic
+  # The ModelRegistry class is used to store and fetch nested models by
+  # their fullname. An optional namespace prefix can be removed from the full
+  # name that is used to store and fetch models.
+  class ModelRegistry
+
+    def initialize(remove_namespace_prefix: nil)
+      @prefix = remove_namespace_prefix
+      @hash = Hash.new
+    end
+
+    def [](fullname)
+      @hash.fetch(fullname)
+    end
+
+    def register(model)
+      raise 'models with a key schema are not supported' if model.key_avro_schema
+      name = model.avro_schema.fullname
+      name = remove_prefix(name) if @prefix
+      @hash[name] = model
+    end
+
+    def model?(fullname)
+      @hash.key?(fullname)
+    end
+
+    private
+
+    def remove_prefix(name)
+      value =
+        case @prefix
+        when String
+          name[@prefix.length..-1] if name.start_with?(@prefix)
+        when Regexp
+          name.sub(@prefix, '')
+        else
+          raise "unsupported `remove_namespace_prefix` value: #{@prefix}"
+        end
+
+      value.start_with?('.') ? value[1..-1] : value
+    end
+  end
+end

--- a/lib/avromatic/model_registry.rb
+++ b/lib/avromatic/model_registry.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/string/access'
+
 module Avromatic
   # The ModelRegistry class is used to store and fetch nested models by
   # their fullname. An optional namespace prefix can be removed from the full
@@ -20,7 +22,7 @@ module Avromatic
       @hash[name] = model
     end
 
-    def model?(fullname)
+    def registered?(fullname)
       @hash.key?(fullname)
     end
 
@@ -30,14 +32,14 @@ module Avromatic
       value =
         case @prefix
         when String
-          name[@prefix.length..-1] if name.start_with?(@prefix)
+          name.from(@prefix.length) if name.start_with?(@prefix)
         when Regexp
           name.sub(@prefix, '')
         else
           raise "unsupported `remove_namespace_prefix` value: #{@prefix}"
         end
 
-      value.start_with?('.') ? value[1..-1] : value
+      value.start_with?('.') ? value.from(1) : value
     end
   end
 end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.9.0.rc1'.freeze
+  VERSION = '0.9.0.rc2'.freeze
 end

--- a/spec/avromatic/model/builder_nested_models_spec.rb
+++ b/spec/avromatic/model/builder_nested_models_spec.rb
@@ -48,7 +48,7 @@ describe Avromatic::Model::Builder, 'nested_models' do
     it "uses the specified registry for nested models" do
       aggregate_failures do
         expect(model.nested_models['test.bar.sub_rec']).to equal(model.attribute_set['sub'].primitive)
-        expect(Avromatic.nested_models.model?('test.bar.sub_rec')).to eql(false)
+        expect(Avromatic.nested_models.registered?('test.bar.sub_rec')).to eql(false)
       end
     end
 

--- a/spec/avromatic/model/builder_nested_models_spec.rb
+++ b/spec/avromatic/model/builder_nested_models_spec.rb
@@ -1,0 +1,65 @@
+describe Avromatic::Model::Builder, 'nested_models' do
+  let(:schema) do
+    Avro::Builder.build_schema do
+      record :rec do
+        required :sub, :record, type_name: :sub_rec, type_namespace: 'test.bar' do
+          required :s, :string
+        end
+        optional :opt_sub, :sub_rec
+      end
+    end
+  end
+  let(:schema2) do
+    Avro::Builder.build_schema do
+      record :rec2 do
+        required :same, :record, type_name: :sub_rec, type_namespace: 'test.bar' do
+          required :s, :string
+        end
+      end
+    end
+  end
+
+  context "when the nested_models option is not specified" do
+    let(:model) { described_class.model(schema: schema) }
+    let(:model2) { described_class.model(schema: schema2) }
+
+    it "registers nested models in the Avromatic registry" do
+      expect(model.nested_models['test.bar.sub_rec'])
+        .to equal(Avromatic.nested_models['test.bar.sub_rec'])
+    end
+
+    it "reuses nested models for multiple fields" do
+      expect(model.attribute_set['sub'].primitive)
+        .to equal(model.attribute_set['opt_sub'].primitive)
+    end
+
+    it "reuses nested models for multiple models" do
+      expect(model.attribute_set['sub'].primitive)
+        .to equal(model2.attribute_set['same'].primitive)
+    end
+  end
+
+  context "when the nested_models option is specified" do
+    let(:registry) { Avromatic::ModelRegistry.new }
+    let(:model) { described_class.model(schema: schema, nested_models: registry) }
+    let(:registry2) { Avromatic::ModelRegistry.new }
+    let(:model2) { described_class.model(schema: schema2, nested_models: registry2) }
+
+    it "uses the specified registry for nested models" do
+      aggregate_failures do
+        expect(model.nested_models['test.bar.sub_rec']).to equal(model.attribute_set['sub'].primitive)
+        expect(Avromatic.nested_models.model?('test.bar.sub_rec')).to eql(false)
+      end
+    end
+
+    it "reuses nested models for multiple fields" do
+      expect(model.attribute_set['sub'].primitive)
+        .to equal(model.attribute_set['opt_sub'].primitive)
+    end
+
+    it "does not reuse nested models for models with different registries" do
+      expect(model.attribute_set['sub'].primitive)
+        .not_to equal(model2.attribute_set['same'].primitive)
+    end
+  end
+end

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -1,6 +1,3 @@
-require 'spec_helper'
-require 'avro/builder'
-
 describe Avromatic::Model::Builder do
   let(:schema_store) { Avromatic.schema_store }
   let(:schema) { schema_store.find(schema_name) }

--- a/spec/avromatic/model_registry_spec.rb
+++ b/spec/avromatic/model_registry_spec.rb
@@ -1,20 +1,20 @@
 describe Avromatic::ModelRegistry do
   let(:model) { Avromatic::Model.model(schema_name: 'test.nested_record') }
 
-  describe "#model?" do
+  describe "#registered?" do
     let(:instance) { described_class.new }
 
     context "for a model that has not been registered" do
       it "returns false" do
-        expect(instance.model?('test.nested_record')).to eql(false)
+        expect(instance.registered?('test.nested_record')).to eql(false)
       end
     end
 
-    context "for  model that has been registered" do
+    context "for model that has been registered" do
       before { instance.register(model) }
 
       it "returns true" do
-        expect(instance.model?('test.nested_record')).to eql(true)
+        expect(instance.registered?('test.nested_record')).to eql(true)
       end
     end
   end

--- a/spec/avromatic/model_registry_spec.rb
+++ b/spec/avromatic/model_registry_spec.rb
@@ -1,0 +1,97 @@
+describe Avromatic::ModelRegistry do
+  let(:model) { Avromatic::Model.model(schema_name: 'test.nested_record') }
+
+  describe "#model?" do
+    let(:instance) { described_class.new }
+
+    context "for a model that has not been registered" do
+      it "returns false" do
+        expect(instance.model?('test.nested_record')).to eql(false)
+      end
+    end
+
+    context "for  model that has been registered" do
+      before { instance.register(model) }
+
+      it "returns true" do
+        expect(instance.model?('test.nested_record')).to eql(true)
+      end
+    end
+  end
+
+  context "without a namespace prefix to remove" do
+    let(:instance) { described_class.new }
+
+    it "stores a model by its fullname" do
+      instance.register(model)
+      expect(instance['test.nested_record']).to equal(model)
+    end
+
+    context "for a model with a key schema" do
+      let(:model) do
+        Avromatic::Model.model(key_schema_name: 'test.encode_key',
+                               schema_name: 'test.encode_value')
+      end
+
+      it "raises an error" do
+        expect { instance.register(model) }
+          .to raise_error('models with a key schema are not supported')
+      end
+    end
+
+    context "when a model has not been registered" do
+      it "raises an error" do
+        expect { instance['test.fnord'] }
+          .to raise_error(/key not found: "test.fnord"/)
+      end
+    end
+  end
+
+  context "with a namespace prefix to remove" do
+    let(:multilevel_model) do
+      schema = Avro::Builder.build_schema do
+        record :rec, namespace: 'test.sub' do
+          required :i, :int
+        end
+      end
+      Avromatic::Model.model(schema: schema)
+    end
+
+    context "with a String prefix" do
+      let(:instance) { described_class.new(remove_namespace_prefix: 'test') }
+
+      it "stores a model by its fullname with prefix removed" do
+        instance.register(model)
+        expect(instance['nested_record']).to equal(model)
+      end
+
+      it "only removes the matching namespace prefix" do
+        instance.register(multilevel_model)
+        expect(instance['sub.rec']).to equal(multilevel_model)
+      end
+    end
+
+    context "with a Regexp prefix" do
+      let(:instance) { described_class.new(remove_namespace_prefix: /([\w]+\.)+/) }
+
+      it "stores a model by its fullname with prefix removed" do
+        instance.register(model)
+        expect(instance['nested_record']).to equal(model)
+      end
+
+      it "only removes the matching namespace prefix" do
+        instance.register(multilevel_model)
+        expect(instance['rec']).to equal(multilevel_model)
+      end
+    end
+
+    context "with an invalid prefix value" do
+      let(:instance) { described_class.new(remove_namespace_prefix: 1) }
+
+      it "raises an error" do
+        expect { instance.register(model) }
+          .to raise_error('unsupported `remove_namespace_prefix` value: 1')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ SimpleCov.start do
   minimum_coverage 98
 end
 
+require 'avro/builder'
 require 'avromatic'
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
@@ -19,6 +20,7 @@ RSpec.configure do |config|
     Avromatic.schema_store = AvroTurf::SchemaStore.new(path: 'spec/avro/schema')
     Avromatic.build_messaging!
     Avromatic.type_registry.clear
+    Avromatic.nested_models = Avromatic::ModelRegistry.new
   end
 end
 


### PR DESCRIPTION
Nested models are stored in a `ModelRegistry` (`Avromatic.nested_models`). This registry is inherited by generated models, but can also be overridden. Models in the registry can be retrieved by schema full name, optionally with a namespace prefix removed.

Also, added README info on experimental union support.

Prime: @jturkel 