### PR TITLE
WIP: Nested model methods spike

### DIFF
--- a/lib/avromatic/model/nested_models.rb
+++ b/lib/avromatic/model/nested_models.rb
@@ -23,6 +23,32 @@ module Avromatic
             nested_models.register(nested_model)
           end
         end
+
+        def method_missing(name, *_args)
+          fullname = registered_model_fullname(name)
+          fullname ? define_nested_model_method(name, fullname) : super
+        end
+
+        def respond_to_missing?(name, _include_all)
+          !!registered_model_fullname(name) || super
+        end
+
+        private
+
+        def define_nested_model_method(method_name, fullname)
+          nested_models[fullname].tap do |nested_model|
+            define_singleton_method(method_name) { nested_model }
+          end
+        end
+
+        def registered_model_fullname(name)
+          fullname = fullname_from_method(name)
+          fullname if fullname && nested_models.registered?(fullname)
+        end
+
+        def fullname_from_method(name)
+          name.to_s.gsub('__', '.').sub!(/_model$/, '')
+        end
       end
     end
   end


### PR DESCRIPTION
Experiment with adding methods to return nested models.

Method missing is used initially to lookup the model. If a model is found, then a method is defined on the current model.

To make the mapping between schema full names and methods more predictable, periods in full names are replaced by two underscores:
- For the schema 'admin.user': `admin__user_model`
- For the schema 'admin_user': `admin_user_model` (hopefully an organization doesn't use both!)

(This means that double underscores and trailing underscores are not supported in schema names.)

Prime: @jturkel 