### PR TITLE
Support recursive models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Experimental: Add support for more than one non-null type in a union.
 - Allow nested models to be referenced and reused.
 - Fix the serialization of nested complex types.
+- Add support for recursive models.
 
 ## v0.8.0
 - Add support for logical types. Currently this requires using the

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -21,6 +21,8 @@ module Avromatic
 
       module ClassMethods
         def add_avro_fields
+          register!
+
           if key_avro_schema
             check_for_field_conflicts!
             define_avro_attributes(key_avro_schema)

--- a/lib/avromatic/model/nested_models.rb
+++ b/lib/avromatic/model/nested_models.rb
@@ -9,18 +9,25 @@ module Avromatic
 
       module ClassMethods
         def build_nested_model(schema)
-          fullname = schema.fullname
+          fullname = nested_models.remove_prefix(schema.fullname)
 
           if nested_models.registered?(fullname)
             nested_models[fullname]
           else
             nested_model = Avromatic::Model.model(schema: schema,
-                                                  nested_models: nested_models)
+                                                  nested_models: nested_models,
+                                                  register: true)
             # Register the generated model with Axiom to prevent it being
             # treated as a BasicObject.
             # See https://github.com/solnic/virtus/issues/284#issuecomment-56405137
             Axiom::Types::Object.new { primitive(nested_model) }
-            nested_models.register(nested_model)
+          end
+        end
+
+        # Register this model if it can be used as a nested model.
+        def register!
+          if key_avro_schema.nil? && value_avro_schema.type_sym == :record
+            nested_models.register(self)
           end
         end
       end

--- a/lib/avromatic/model_registry.rb
+++ b/lib/avromatic/model_registry.rb
@@ -18,7 +18,7 @@ module Avromatic
     def register(model)
       raise 'models with a key schema are not supported' if model.key_avro_schema
       name = model.avro_schema.fullname
-      name = remove_prefix(name) if @prefix
+      name = remove_prefix(name)
       @hash[name] = model
     end
 
@@ -26,13 +26,13 @@ module Avromatic
       @hash.key?(fullname)
     end
 
-    private
-
     def remove_prefix(name)
+      return name if @prefix.nil?
+
       value =
         case @prefix
         when String
-          name.from(@prefix.length) if name.start_with?(@prefix)
+          name.start_with?(@prefix) ? name.from(@prefix.length) : name
         when Regexp
           name.sub(@prefix, '')
         else

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.9.0.rc2'.freeze
+  VERSION = '0.9.0.rc3'.freeze
 end

--- a/spec/avro/dsl/test/recursive.rb
+++ b/spec/avro/dsl/test/recursive.rb
@@ -1,0 +1,4 @@
+record :recursive, namespace: :test do
+  required :s, :string
+  optional :child, :recursive
+end

--- a/spec/avro/schema/test/recursive.avsc
+++ b/spec/avro/schema/test/recursive.avsc
@@ -1,0 +1,19 @@
+{
+  "type": "record",
+  "name": "recursive",
+  "namespace": "test",
+  "fields": [
+    {
+      "name": "s",
+      "type": "string"
+    },
+    {
+      "name": "child",
+      "type": [
+        "null",
+        "test.recursive"
+      ],
+      "default": null
+    }
+  ]
+}

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -197,6 +197,12 @@ describe Avromatic::Model::Builder do
 
       it_behaves_like "a generated model"
     end
+
+    context "recursive models" do
+      let(:schema_name) { 'test.recursive' }
+
+      it_behaves_like "a generated model"
+    end
   end
 
   context "validation" do

--- a/spec/avromatic/model_registry_spec.rb
+++ b/spec/avromatic/model_registry_spec.rb
@@ -69,6 +69,15 @@ describe Avromatic::ModelRegistry do
         instance.register(multilevel_model)
         expect(instance['sub.rec']).to equal(multilevel_model)
       end
+
+      context "for a model that does not match the prefix" do
+        let(:instance) { described_class.new(remove_namespace_prefix: 'test.sub') }
+
+        it "stores the model by its fullname" do
+          instance.register(model)
+          expect(instance['test.nested_record']).to equal(model)
+        end
+      end
     end
 
     context "with a Regexp prefix" do


### PR DESCRIPTION
Any model that can be used as a nested model (i.e. it only has a value schema) is now automatically registered before building attributes.

This change also fixes a bug looking up previously registered models and an issue registering models that do not match a prefix.

Prime: @jturkel 