### PR TITLE
Nested models Axiom::Types fix

### DIFF
--- a/lib/avromatic/model/nested_models.rb
+++ b/lib/avromatic/model/nested_models.rb
@@ -14,19 +14,20 @@ module Avromatic
           if nested_models.registered?(fullname)
             nested_models[fullname]
           else
-            nested_model = Avromatic::Model.model(schema: schema,
-                                                  nested_models: nested_models,
-                                                  register: true)
-            # Register the generated model with Axiom to prevent it being
-            # treated as a BasicObject.
-            # See https://github.com/solnic/virtus/issues/284#issuecomment-56405137
-            Axiom::Types::Object.new { primitive(nested_model) }
+            Avromatic::Model.model(schema: schema,
+                                   nested_models: nested_models)
           end
         end
 
         # Register this model if it can be used as a nested model.
         def register!
           if key_avro_schema.nil? && value_avro_schema.type_sym == :record
+            # Register the generated model with Axiom to prevent it being
+            # treated as a BasicObject.
+            # See https://github.com/solnic/virtus/issues/284#issuecomment-56405137
+            nested_model = self
+            Axiom::Types::Object.new { primitive(nested_model) }
+
             nested_models.register(self)
           end
         end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.9.0.rc3'.freeze
+  VERSION = '0.9.0.rc4'.freeze
 end

--- a/spec/avromatic/model/raw_serialization_spec.rb
+++ b/spec/avromatic/model/raw_serialization_spec.rb
@@ -160,6 +160,41 @@ describe Avromatic::Model::RawSerialization do
       end
     end
 
+    context "array of pre-registed nested models" do
+      let(:nested_schema) do
+        Avro::Builder.build_schema do
+          record :int_rec do
+            required :i, :int
+          end
+        end
+      end
+      let!(:nested_model) do
+        Avromatic::Model.model(schema: nested_schema)
+      end
+      let(:schema) do
+        Avro::Builder.build_schema do
+          record :int_rec do
+            required :i, :int
+          end
+
+          record :transform do
+            required :a, :array, items: :int_rec
+          end
+        end
+      end
+      let(:test_class) do
+        Avromatic::Model.model(schema: schema)
+      end
+      let(:values) do
+        { a: [{ i: 1 }, { i: 2 }] }
+      end
+      let(:decoded) { test_class.avro_raw_decode(value: avro_raw_value) }
+
+      it "encodes and decodes the model" do
+        expect(instance).to eq(decoded)
+      end
+    end
+
     context "array of unions" do
       let(:schema) do
         Avro::Builder.build_schema do


### PR DESCRIPTION
Models that can be nested are now automatically added to the model registry when they are built. This fix moves the registration with `Axiom::Types` to the same place. Without this fix, a model could be built and registered with Avromatic without being recognized by Axiom.

Prime: @jturkel 