### PR TITLE
Allow empty required array and map fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Allow nested models to be referenced and reused.
 - Fix the serialization of nested complex types.
 - Add support for recursive models.
+- Allow required array and map fields to be empty. Only nil values for required
+  array and map fields are now considered invalid.
 
 ## v0.8.0
 - Add support for logical types. Currently this requires using the

--- a/avromatic.gemspec
+++ b/avromatic.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |spec|
   # For FakeSchemaRegistryServer
   spec.add_development_dependency 'sinatra'
   spec.add_development_dependency 'salsify_rubocop', '~> 0.42.0'
-  spec.add_development_dependency 'overcommit'
+  spec.add_development_dependency 'overcommit', '0.35.0'
   spec.add_development_dependency 'appraisal'
 end

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -85,7 +85,7 @@ module Avromatic
         def add_required_validation(field)
           if required?(field) && field.default == :no_default
             case field.type.type_sym
-            when :array, :map
+            when :array, :map, :boolean
               validates(field.name, exclusion: { in: [nil], message: "can't be nil" })
             else
               validates(field.name, presence: true)

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -84,7 +84,12 @@ module Avromatic
 
         def add_required_validation(field)
           if required?(field) && field.default == :no_default
-            validates(field.name, presence: true)
+            case field.type.type_sym
+            when :array, :map
+              validates(field.name, exclusion: { in: [nil], message: "can't be nil" })
+            else
+              validates(field.name, presence: true)
+            end
           end
         end
 

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.9.0.rc4'.freeze
+  VERSION = '0.9.0.rc5'.freeze
 end

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -205,47 +205,6 @@ describe Avromatic::Model::Builder do
     end
   end
 
-  context "validation" do
-    context "fixed" do
-      let(:schema_name) { 'test.named_fields' }
-
-      it "validates the length of a fixed field" do
-        instance = test_class.new(f: '12345678')
-        expect(instance).to be_invalid
-        expect(instance.errors[:f]).to include('is the wrong length (should be 7 characters)')
-      end
-    end
-
-    context "enum" do
-      let(:schema_name) { 'test.named_fields' }
-
-      it "validates that an enum is a valid symbol" do
-        instance = test_class.new(e: :C)
-        expect(instance).to be_invalid
-        expect(instance.errors[:e]).to include('is not included in the list')
-      end
-    end
-
-    context "required" do
-      let(:schema_name) { 'test.primitive_types' }
-
-      it "validates that required fields must be present" do
-        instance = test_class.new
-        expect(instance).to be_invalid
-        expect(instance.errors[:s]).to include('can\'t be blank')
-        expect(instance.errors.keys.map(&:to_s)).to match_array(attribute_names)
-      end
-    end
-
-    context "optional" do
-      let(:schema_name) { 'test.with_union' }
-
-      it "does not require optional fields to be present" do
-        expect(test_class.new).to be_valid
-      end
-    end
-  end
-
   context "coercion" do
     # This is important for the eventual encoding of a model to Avro
 

--- a/spec/avromatic/model/builder_validation_spec.rb
+++ b/spec/avromatic/model/builder_validation_spec.rb
@@ -33,9 +33,19 @@ describe Avromatic::Model::Builder, 'validation' do
 
       it "validates that required fields must be present" do
         instance = test_class.new
-        expect(instance).to be_invalid
-        expect(instance.errors[:s]).to include("can't be blank")
-        expect(instance.errors.keys.map(&:to_s)).to match_array(attribute_names)
+        aggregate_failures do
+          expect(instance).to be_invalid
+          expect(instance.errors[:s]).to include("can't be blank")
+          expect(instance.errors[:tf]).to include("can't be nil")
+          expect(instance.errors.keys.map(&:to_s)).to match_array(attribute_names)
+        end
+      end
+
+      context "boolean" do
+        it "allows a boolean field to be false" do
+          instance = test_class.new(tf: false)
+          expect(instance.errors.keys).not_to include(:tf)
+        end
       end
     end
 

--- a/spec/avromatic/model/builder_validation_spec.rb
+++ b/spec/avromatic/model/builder_validation_spec.rb
@@ -1,0 +1,95 @@
+describe Avromatic::Model::Builder, 'validation' do
+  let(:schema) { schema_store.find(schema_name) }
+  let(:test_class) do
+    described_class.model(schema_name: schema_name)
+  end
+  let(:attribute_names) do
+    test_class.attribute_set.map(&:name).map(&:to_s)
+  end
+
+  context "fixed" do
+    let(:schema_name) { 'test.named_fields' }
+
+    it "validates the length of a fixed field" do
+      instance = test_class.new(f: '12345678')
+      expect(instance).to be_invalid
+      expect(instance.errors[:f]).to include('is the wrong length (should be 7 characters)')
+    end
+  end
+
+  context "enum" do
+    let(:schema_name) { 'test.named_fields' }
+
+    it "validates that an enum is a valid symbol" do
+      instance = test_class.new(e: :C)
+      expect(instance).to be_invalid
+      expect(instance.errors[:e]).to include('is not included in the list')
+    end
+  end
+
+  context "required" do
+    context "primitive types" do
+      let(:schema_name) { 'test.primitive_types' }
+
+      it "validates that required fields must be present" do
+        instance = test_class.new
+        expect(instance).to be_invalid
+        expect(instance.errors[:s]).to include("can't be blank")
+        expect(instance.errors.keys.map(&:to_s)).to match_array(attribute_names)
+      end
+    end
+
+    context "array" do
+      let(:schema) do
+        Avro::Builder.build_schema do
+          record :has_array do
+            required :a, :array, items: :int
+          end
+        end
+      end
+      let(:test_class) { described_class.model(schema: schema) }
+
+      it "validates that a required array is not nil" do
+        pending 'Virtus coerces nil values to an empty array'
+        instance = test_class.new(a: nil)
+        expect(instance).to be_invalid
+        expect(instance.errors[:a]).to include("can't be nil")
+      end
+
+      it "allows a required array to be empty" do
+        instance = test_class.new(a: [])
+        expect(instance).to be_valid
+      end
+    end
+
+    context "map" do
+      let(:schema) do
+        Avro::Builder.build_schema do
+          record :has_map do
+            required :m, :map, values: :int
+          end
+        end
+      end
+      let(:test_class) { described_class.model(schema: schema) }
+
+      it "validates that a required map is not nil" do
+        instance = test_class.new(m: nil)
+        expect(instance).to be_invalid
+        expect(instance.errors[:m]).to include("can't be nil")
+      end
+
+      it "allows a required map to be empty" do
+        instance = test_class.new(m: {})
+        expect(instance).to be_valid
+      end
+    end
+  end
+
+  context "optional" do
+    let(:schema_name) { 'test.with_union' }
+
+    it "does not require optional fields to be present" do
+      expect(test_class.new).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
Previously a presence check was used for all required fields. This check uses `blank?` which has the effect of marking empty arrays and maps as invalid.

As part of this change, the validation specs were moved into a separate file.

Prime: @jturkel 