### PR TITLE
Validate nested models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Add support for recursive models.
 - Allow required array and map fields to be empty. Only nil values for required
   array and map fields are now considered invalid.
+- Validate nested models. This does not apply to nested models embedded
+  within other complex types (array, map, and union).
 
 ## v0.8.0
 - Add support for logical types. Currently this requires using the

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -77,9 +77,22 @@ module Avromatic
                       inclusion: { in: Set.new(field.type.symbols.map(&:freeze)).freeze })
           when :fixed
             validates(field.name, length: { is: field.type.size })
+          when :record
+            validate_record(field.name)
           end
 
           add_required_validation(field)
+        end
+
+        def validate_record(field_name)
+          validate do |instance|
+            record = instance.send(field_name)
+            if record && record.invalid?
+              record.errors.each do |key, message|
+                errors.add(field_name.to_sym, "invalid: #{key} #{message}")
+              end
+            end
+          end
         end
 
         def add_required_validation(field)

--- a/spec/avromatic/model/builder_validation_spec.rb
+++ b/spec/avromatic/model/builder_validation_spec.rb
@@ -93,6 +93,27 @@ describe Avromatic::Model::Builder, 'validation' do
         expect(instance).to be_valid
       end
     end
+
+    context "nested records" do
+      let(:schema) do
+        Avro::Builder.build_schema do
+          record :has_record do
+            required :sub, :record, type_name: 'sub_type' do
+              required :i, :int
+              required :s, :string
+            end
+          end
+        end
+      end
+      let(:test_class) { described_class.model(schema: schema) }
+
+      it "validates nested records" do
+        instance = test_class.new(sub: test_class.nested_models['sub_type'].new)
+        expect(instance).to be_invalid
+        expect(instance.errors[:sub]).to include("invalid: i can't be blank")
+        expect(instance.errors[:sub]).to include("invalid: s can't be blank")
+      end
+    end
   end
 
   context "optional" do


### PR DESCRIPTION
This change makes incremental progress on validation. Nested models are validated but only if the nested model is used directly as the type for a field. Nested models embedded within complex types will be handled separately.

Prime: @jturkel 