### PR TITLE
Only allow nested models to be registered once

### DIFF
--- a/lib/avromatic/model_registry.rb
+++ b/lib/avromatic/model_registry.rb
@@ -19,6 +19,7 @@ module Avromatic
       raise 'models with a key schema are not supported' if model.key_avro_schema
       name = model.avro_schema.fullname
       name = remove_prefix(name)
+      raise "'#{name}' has already been registered" if registered?(name)
       @hash[name] = model
     end
 

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.9.0.rc5'.freeze
+  VERSION = '0.9.0.rc6'.freeze
 end

--- a/spec/avromatic/model_registry_spec.rb
+++ b/spec/avromatic/model_registry_spec.rb
@@ -27,6 +27,16 @@ describe Avromatic::ModelRegistry do
       expect(instance['test.nested_record']).to equal(model)
     end
 
+    context "with a previously registered model" do
+      before { instance.register(model) }
+
+      it "raises an error" do
+        expect do
+          instance.register(model)
+        end.to raise_error("'test.nested_record' has already been registered")
+      end
+    end
+
     context "for a model with a key schema" do
       let(:model) do
         Avromatic::Model.model(key_schema_name: 'test.encode_key',


### PR DESCRIPTION
This change only allows a model's full name to be registered once for the same registry. Any attempt to register the same name again raises an error.

Prime: @jturkel 
