### PR TITLE
Nested validation of records embedded in complex types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 - Add support for recursive models.
 - Allow required array and map fields to be empty. Only nil values for required
   array and map fields are now considered invalid.
-- Validate nested models. This does not apply to nested models embedded
-  within other complex types (array, map, and union).
+- Validate nested models. This includes models embedded within other complex
+  types (array, map, and union).
 
 ## v0.8.0
 - Add support for logical types. Currently this requires using the

--- a/avromatic.gemspec
+++ b/avromatic.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock'
-  spec.add_development_dependency 'avro-builder', '>= 0.11.0'
+  spec.add_development_dependency 'avro-builder', '>= 0.12.0'
   # For FakeSchemaRegistryServer
   spec.add_development_dependency 'sinatra'
   spec.add_development_dependency 'salsify_rubocop', '~> 0.42.0'

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -77,22 +77,11 @@ module Avromatic
                       inclusion: { in: Set.new(field.type.symbols.map(&:freeze)).freeze })
           when :fixed
             validates(field.name, length: { is: field.type.size })
-          when :record
-            validate_record(field.name)
+          when :record, :array, :map, :union
+            validate_complex(field.name)
           end
 
           add_required_validation(field)
-        end
-
-        def validate_record(field_name)
-          validate do |instance|
-            record = instance.send(field_name)
-            if record && record.invalid?
-              record.errors.each do |key, message|
-                errors.add(field_name.to_sym, "invalid: #{key} #{message}")
-              end
-            end
-          end
         end
 
         def add_required_validation(field)

--- a/lib/avromatic/model/builder.rb
+++ b/lib/avromatic/model/builder.rb
@@ -5,6 +5,7 @@ require 'avromatic/model/configuration'
 require 'avromatic/model/value_object'
 require 'avromatic/model/configurable'
 require 'avromatic/model/nested_models'
+require 'avromatic/model/validation'
 require 'avromatic/model/attribute/union'
 require 'avromatic/model/attributes'
 require 'avromatic/model/attribute/record'
@@ -44,6 +45,7 @@ module Avromatic
           Virtus.value_object,
           Avromatic::Model::Configurable,
           Avromatic::Model::NestedModels,
+          Avromatic::Model::Validation,
           Avromatic::Model::Attributes,
           Avromatic::Model::ValueObject,
           Avromatic::Model::RawSerialization,

--- a/lib/avromatic/model/validation.rb
+++ b/lib/avromatic/model/validation.rb
@@ -1,0 +1,48 @@
+module Avromatic
+  module Model
+    module Validation
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+
+        # Returns an array of messages
+        def validate_nested_value(value)
+          case value
+          when Avromatic::Model::Attributes
+            validate_record_value(value)
+          when Array
+            value.map.with_index do |element, index|
+              validate_nested_value(element).map do |message|
+                "[#{index}]#{message}"
+              end
+            end.flatten
+          when Hash
+            value.map do |key, map_value|
+              validate_nested_value(map_value).map do |message|
+                "['#{key}']#{message}"
+              end
+            end.flatten
+          end || []
+        end
+
+        private
+
+        def validate_complex(field_name)
+          validate do |instance|
+            value = instance.send(field_name)
+            messages = self.class.validate_nested_value(value)
+            messages.each { |message| instance.errors.add(field_name.to_sym, message) }
+          end
+        end
+
+        def validate_record_value(record)
+          if record && record.invalid?
+            record.errors.map do |key, message|
+              ".#{key} #{message}".gsub(' .', '.')
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/avromatic/model/validation.rb
+++ b/lib/avromatic/model/validation.rb
@@ -11,18 +11,22 @@ module Avromatic
           when Avromatic::Model::Attributes
             validate_record_value(value)
           when Array
-            value.map.with_index do |element, index|
+            value.flat_map.with_index do |element, index|
               validate_nested_value(element).map do |message|
                 "[#{index}]#{message}"
               end
-            end.flatten
+            end
           when Hash
-            value.map do |key, map_value|
+            value.flat_map do |key, map_value|
+              # keys for the Avro map type are always strings and do not require
+              # validation
               validate_nested_value(map_value).map do |message|
                 "['#{key}']#{message}"
               end
-            end.flatten
-          end || []
+            end
+          else
+            []
+          end
         end
 
         private
@@ -40,6 +44,8 @@ module Avromatic
             record.errors.map do |key, message|
               ".#{key} #{message}".gsub(' .', '.')
             end
+          else
+            []
           end
         end
       end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.9.0.rc6'.freeze
+  VERSION = '0.9.0.rc7'.freeze
 end


### PR DESCRIPTION
This change completes validation for all of the places where nested models can appear. 

Instead of attempting to predict (based on the schema) where nested, complex types will occur, this implementation checks any complex types recursively.

Prime: @jturkel 