### PR TITLE
Coerce timestamps to the supported precision

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,5 @@ AllCops:
 Style/MultilineBlockChain:
   Enabled: false
 
+Style/NumericPredicate:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 - Add support for recursive models.
 - Allow required array and map fields to be empty. Only nil values for required
   array and map fields are now considered invalid.
-- Validate nested models. This does not apply to nested models embedded
-  within other complex types (array, map, and union).
+- Truncate values for timestamps to the precision supported by the logical type.
 
 ## v0.8.0
 - Add support for logical types. Currently this requires using the

--- a/lib/avromatic/model/attribute/abstract_timestamp.rb
+++ b/lib/avromatic/model/attribute/abstract_timestamp.rb
@@ -1,0 +1,26 @@
+module Avromatic
+  module Model
+    module Attribute
+
+      # This subclass of Virtus::Attribute is used to truncate timestamp values
+      # to the supported precision.
+      class AbstractTimestamp < Virtus::Attribute
+        def coerce(value)
+          return value if value.nil? || value_coerced?(value)
+
+          value.is_a?(Time) ? coerce_time(value) : value
+        end
+
+        def value_coerced?(_value)
+          raise 'subclass must implement `value_coerced?`'
+        end
+
+        private
+
+        def coerce_time(_value)
+          raise 'subclass must implement `coerce_time`'
+        end
+      end
+    end
+  end
+end

--- a/lib/avromatic/model/attribute/abstract_timestamp.rb
+++ b/lib/avromatic/model/attribute/abstract_timestamp.rb
@@ -12,13 +12,13 @@ module Avromatic
         end
 
         def value_coerced?(_value)
-          raise 'subclass must implement `value_coerced?`'
+          raise "#{__method__} must be overridden by #{self.class.name}"
         end
 
         private
 
         def coerce_time(_value)
-          raise 'subclass must implement `coerce_time`'
+          raise "#{__method__} must be overridden by #{self.class.name}"
         end
       end
     end

--- a/lib/avromatic/model/attribute/timestamp_micros.rb
+++ b/lib/avromatic/model/attribute/timestamp_micros.rb
@@ -1,0 +1,23 @@
+require 'avromatic/model/attribute/abstract_timestamp'
+
+module Avromatic
+  module Model
+    module Attribute
+
+      # This subclass is used to truncate timestamp values to microseconds.
+      class TimestampMicros < AbstractTimestamp
+
+        def value_coerced?(value)
+          value.is_a?(Time) && value.nsec % 1000 == 0
+        end
+
+        private
+
+        def coerce_time(value)
+          Time.at(value.to_i, value.usec)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/avromatic/model/attribute/timestamp_micros.rb
+++ b/lib/avromatic/model/attribute/timestamp_micros.rb
@@ -14,6 +14,9 @@ module Avromatic
         private
 
         def coerce_time(value)
+          # value is coerced to a local Time
+          # The Avro representation of a timestamp is Epoch seconds, independent
+          # of time zone.
           Time.at(value.to_i, value.usec)
         end
 

--- a/lib/avromatic/model/attribute/timestamp_millis.rb
+++ b/lib/avromatic/model/attribute/timestamp_millis.rb
@@ -1,0 +1,23 @@
+require 'avromatic/model/attribute/abstract_timestamp'
+
+module Avromatic
+  module Model
+    module Attribute
+
+      # This subclass is used to truncate timestamp values to milliseconds.
+      class TimestampMillis < AbstractTimestamp
+
+        def value_coerced?(value)
+          value.is_a?(Time) && value.usec % 1000 == 0
+        end
+
+        private
+
+        def coerce_time(value)
+          Time.at(value.to_i, value.usec / 1000 * 1000)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/avromatic/model/attribute/timestamp_millis.rb
+++ b/lib/avromatic/model/attribute/timestamp_millis.rb
@@ -14,6 +14,9 @@ module Avromatic
         private
 
         def coerce_time(value)
+          # value is coerced to a local Time
+          # The Avro representation of a timestamp is Epoch seconds, independent
+          # of time zone.
           Time.at(value.to_i, value.usec / 1000 * 1000)
         end
 

--- a/lib/avromatic/model/logical_types.rb
+++ b/lib/avromatic/model/logical_types.rb
@@ -1,11 +1,14 @@
+require 'avromatic/model/attribute/timestamp_micros'
+require 'avromatic/model/attribute/timestamp_millis'
+
 module Avromatic
   module Model
     module LogicalTypes
 
       LOGICAL_TYPE_MAP = {
         'date' => Date,
-        'timestamp-micros' => Time,
-        'timestamp-millis' => Time
+        'timestamp-micros' => Avromatic::Model::Attribute::TimestampMicros,
+        'timestamp-millis' => Avromatic::Model::Attribute::TimestampMillis
       }.freeze
 
       def self.value_class(logical_type)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,12 @@ require 'simplecov'
 
 SimpleCov.start do
   add_filter 'spec'
-  minimum_coverage 98
+  begin
+    Gem::Specification.find_by_name('avro-salsify-fork')
+    minimum_coverage 99
+  rescue Gem::LoadError
+    minimum_coverage 97
+  end
 end
 
 require 'avro/builder'

--- a/spec/support/contexts/logical_types_serialization.rb
+++ b/spec/support/contexts/logical_types_serialization.rb
@@ -6,14 +6,22 @@ shared_examples_for "logical type encoding and decoding" do
     let(:test_class) do
       Avromatic::Model.model(schema_name: schema_name)
     end
-    let(:now) { Time.now }
+    let(:now) do
+      # ensure that the Time value has nanoseconds
+      time = Time.now
+      if time.nsec % 1000 == 0
+        Time.at(time.to_i, (time.nsec + rand(999) + 1) / 1000.0)
+      else
+        time
+      end
+    end
 
     with_logical_types do
       context "supported" do
         let(:values) do
           {
             date: Date.today,
-            ts_msec: Time.at(now.to_i, now.usec / 1000 * 1000),
+            ts_msec: now,
             ts_usec: now,
             unknown: 42
           }


### PR DESCRIPTION
With this change, instances match exactly after a round-trip through serialization and deserialization.

Previously a timestamp stored in a model could have greater precision than a value returned after deserialization.

This removes any need to truncate timestamps before assigning to an Avromatic model.

Prime: @jturkel 