### PR TITLE
New approach for extended model that must be loaded first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # avromatic changelog
 
+## v0.11.0
+- Replace `Avromatic.on_initialize` proc with `Avromatic.preregister_models`
+  array. The models listed by this configuration are added to the registry
+  at the end of `.configure` and prior to code reloading in Rails applications.
+  This is a compatibility breaking change.
+
 ## v0.10.0
 - Add `Avromatic.on_initialize` proc that is called at the end of `.configure`
   and on code reloading in Rails applications.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # avromatic changelog
 
 ## v0.11.0
-- Replace `Avromatic.on_initialize` proc with `Avromatic.preregister_models`
+- Replace `Avromatic.on_initialize` proc with `Avromatic.eager_load_models`
   array. The models listed by this configuration are added to the registry
   at the end of `.configure` and prior to code reloading in Rails applications.
   This is a compatibility breaking change.

--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ Or install it yourself as:
   that is used to store, by full schema name, the generated models that are
   embedded within top-level models. By default a new `Avromatic::ModelRegistry`
   is created.
-* **preregister_models**: An optional array of models that are added to
-  `nested_models` at the end of `Avromatic.configure` and during code reloading
-  in Rails applications. This option is useful for defining models that will
-  be extended when the load order is important.
+* **preregister_models**: An optional array of models, or strings with class
+  names for models, that are added to `nested_models` at the end of
+  `Avromatic.configure` and during code reloading in Rails applications. This
+  option is useful for defining models that will be extended when the load order
+  is important.
 
 #### Using a Schema Registry/Messaging API
  

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Or install it yourself as:
   that is used to store, by full schema name, the generated models that are
   embedded within top-level models. By default a new `Avromatic::ModelRegistry`
   is created.
-* **preregister_models**: An optional array of models, or strings with class
+* **eager_load_models**: An optional array of models, or strings with class
   names for models, that are added to `nested_models` at the end of
   `Avromatic.configure` and during code reloading in Rails applications. This
   option is useful for defining models that will be extended when the load order
@@ -174,7 +174,7 @@ it can be used as a nested model.
 To extend a model that will be used as a nested model, you must ensure that it
 is defined, which will register it, prior it being referenced by another model.
 
-Using the `Avromatic.preregister_models` option allows models that are extended
+Using the `Avromatic.eager_load_models` option allows models that are extended
 and will be used as nested models to be defined at the end of the `.configure`
 block. In Rails applications, these models are also re-registered after
 `nested_models` is cleared when code reloads to ensure that classes load in the
@@ -182,7 +182,7 @@ correct order:
 
 ```ruby
 Avromatic.configure do |config|
-  config.preregister_models = [
+  config.eager_load_models = [
     # reference any extended models that should be defined first
     MyNestedModel
   ]

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Or install it yourself as:
   that is used to store, by full schema name, the generated models that are
   embedded within top-level models. By default a new `Avromatic::ModelRegistry`
   is created.
-* **on_initialize**: An optional Proc that runs at the end of
-  `Avromatic.configure` and during code reloading in Rails applications. This
-  option is useful for defining models that will be extended when the load
-  order is important.
+* **preregister_models**: An optional array of models that are added to
+  `nested_models` at the end of `Avromatic.configure` and during code reloading
+  in Rails applications. This option is useful for defining models that will
+  be extended when the load order is important.
 
 #### Using a Schema Registry/Messaging API
  
@@ -173,18 +173,18 @@ it can be used as a nested model.
 To extend a model that will be used as a nested model, you must ensure that it
 is defined, which will register it, prior it being referenced by another model.
 
-Using the `Avromatic.on_initialize` option allows models that are extended and
-will be used as nested models to be defined at the end of the `.configure`
-block. In Rails applications, this Proc will also be executed after
+Using the `Avromatic.preregister_models` option allows models that are extended
+and will be used as nested models to be defined at the end of the `.configure`
+block. In Rails applications, these models are also re-registered after
 `nested_models` is cleared when code reloads to ensure that classes load in the
 correct order:
 
 ```ruby
 Avromatic.configure do |config|
-  config.on_initialize do
+  config.preregister_models = [
     # reference any extended models that should be defined first
     MyNestedModel
-  end
+  ]
 end
 
 #### Custom Types

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -19,7 +19,7 @@ module Avromatic
 
   def self.configure
     yield self
-    preregister_models!
+    eager_load_models!
   end
 
   def self.build_schema_registry
@@ -42,21 +42,23 @@ module Avromatic
     self.messaging = build_messaging
   end
 
+  # This method is called as a Rails to_prepare block after the application
+  # first initializes and prior to each code reloading.
   def self.prepare!
     nested_models.clear
-    preregister_models!
+    eager_load_models!
   end
 
-  def self.preregister_models=(models)
-    @preregister_model_names = Array(models).map { |model| model.is_a?(Class) ? model.name : model }
+  def self.eager_load_models=(models)
+    @eager_load_model_names = Array(models).map { |model| model.is_a?(Class) ? model.name : model }
   end
 
-  def self.preregister_models!
-    (@preregister_model_names || []).each do |model_name|
-      nested_models.register_if_missing(model_name.constantize)
+  def self.eager_load_models!
+    (@eager_load_model_names || []).each do |model_name|
+      nested_models.ensure_registered_model(model_name.constantize)
     end
   end
-  private_class_method :preregister_models!
+  private_class_method :eager_load_models!
 end
 
 require 'avromatic/railtie' if defined?(Rails)

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -47,8 +47,8 @@ module Avromatic
     preregister_models!
   end
 
-  def self.preregister_models=(value)
-    @preregister_model_names = Array(value).map { |model| model.is_a?(Class) ? model.name : model }
+  def self.preregister_models=(models)
+    @preregister_model_names = Array(models).map { |model| model.is_a?(Class) ? model.name : model }
   end
 
   def self.preregister_models!

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -3,11 +3,12 @@ require 'avromatic/model'
 require 'avromatic/model_registry'
 require 'avro_turf'
 require 'avro_turf/messaging'
+require 'active_support/core_ext/string/inflections'
 
 module Avromatic
   class << self
     attr_accessor :schema_registry, :registry_url, :schema_store, :logger,
-                  :messaging, :type_registry, :nested_models, :preregister_models
+                  :messaging, :type_registry, :nested_models
 
     delegate :register_type, to: :type_registry
   end
@@ -15,7 +16,6 @@ module Avromatic
   self.nested_models = ModelRegistry.new
   self.logger = Logger.new($stdout)
   self.type_registry = Avromatic::Model::TypeRegistry.new
-  self.preregister_models = []
 
   def self.configure
     yield self
@@ -47,9 +47,13 @@ module Avromatic
     preregister_models!
   end
 
+  def self.preregister_models=(value)
+    @preregister_model_names = Array(value).map { |model| model.is_a?(Class) ? model.name : model }
+  end
+
   def self.preregister_models!
-    preregister_models.each do |model|
-      nested_models.register_if_missing(model)
+    (@preregister_model_names || []).each do |model_name|
+      nested_models.register_if_missing(model_name.constantize)
     end
   end
   private_class_method :preregister_models!

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -21,6 +21,8 @@ module Avromatic
 
       module ClassMethods
         def add_avro_fields
+          # models are registered in Avromatic.nested_models at this point to
+          # ensure that they are available as fields for recursive models.
           register!
 
           if key_avro_schema

--- a/lib/avromatic/model_registry.rb
+++ b/lib/avromatic/model_registry.rb
@@ -31,6 +31,12 @@ module Avromatic
       @hash.key?(fullname)
     end
 
+    def register_if_missing(model)
+      name = model.avro_schema.fullname
+      name = remove_prefix(name)
+      @hash[name] = model unless registered?(name)
+    end
+
     def remove_prefix(name)
       return name if @prefix.nil?
 

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.11.0.rc0'.freeze
+  VERSION = '0.11.0.rc1'.freeze
 end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.11.0.rc1'.freeze
+  VERSION = '0.11.0.rc2'.freeze
 end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.10.0'.freeze
+  VERSION = '0.11.0.rc0'.freeze
 end

--- a/spec/avromatic/model_registry_spec.rb
+++ b/spec/avromatic/model_registry_spec.rb
@@ -1,9 +1,8 @@
 describe Avromatic::ModelRegistry do
   let(:model) { Avromatic::Model.model(schema_name: 'test.nested_record') }
+  let(:instance) { described_class.new }
 
   describe "#registered?" do
-    let(:instance) { described_class.new }
-
     context "for a model that has not been registered" do
       it "returns false" do
         expect(instance.registered?('test.nested_record')).to eql(false)
@@ -19,9 +18,24 @@ describe Avromatic::ModelRegistry do
     end
   end
 
-  context "without a namespace prefix to remove" do
-    let(:instance) { described_class.new }
+  describe "#register_if_missing" do
+    context "for a model that has not been registered" do
+      it "registers the model" do
+        instance.register_if_missing(model)
+        expect(instance.registered?('test.nested_record')).to eql(true)
+      end
+    end
 
+    context "for model that has been registered" do
+      before { instance.register(model) }
+
+      it "does not raise an error" do
+        expect { instance.register_if_missing(model) }.not_to raise_error
+      end
+    end
+  end
+
+  context "without a namespace prefix to remove" do
     it "stores a model by its fullname" do
       instance.register(model)
       expect(instance['test.nested_record']).to equal(model)

--- a/spec/avromatic/model_registry_spec.rb
+++ b/spec/avromatic/model_registry_spec.rb
@@ -27,10 +27,16 @@ describe Avromatic::ModelRegistry do
     end
 
     context "for model that has been registered" do
+      let(:model_copy) { model.dup }
       before { instance.register(model) }
 
       it "does not raise an error" do
-        expect { instance.register_if_missing(model) }.not_to raise_error
+        expect { instance.register_if_missing(model_copy) }.not_to raise_error
+      end
+
+      it "does not replace the registered version of the model" do
+        instance.register_if_missing(model_copy)
+        expect(instance['test.nested_record']).to equal(model)
       end
     end
   end

--- a/spec/avromatic_spec.rb
+++ b/spec/avromatic_spec.rb
@@ -33,15 +33,16 @@ describe Avromatic do
     end
   end
 
-  context "preregistering models" do
+  context "eager loading models" do
     before do
       stub_const('NestedRecord', Avromatic::Model.model(schema_name: 'test.nested_record'))
+      described_class.nested_models.clear
     end
 
     context "at the end of configure" do
       it "registers models" do
         described_class.configure do |config|
-          config.preregister_models = NestedRecord
+          config.eager_load_models = NestedRecord
         end
         expect(described_class.nested_models.registered?('test.nested_record')).to eql(true)
       end
@@ -58,7 +59,7 @@ describe Avromatic do
       end
 
       it "registers models" do
-        described_class.preregister_models = %w(NestedRecord)
+        described_class.eager_load_models = %w(NestedRecord)
         described_class.prepare!
         expect(described_class.nested_models.registered?('test.value')).to eql(false)
       end

--- a/spec/avromatic_spec.rb
+++ b/spec/avromatic_spec.rb
@@ -1,6 +1,6 @@
 describe Avromatic do
   it "has a version number" do
-    expect(Avromatic::VERSION).not_to be nil
+    expect(Avromatic::VERSION).not_to be_nil
   end
 
   describe ".build_schema_registry" do
@@ -29,6 +29,38 @@ describe Avromatic do
 
       it "does not cache the schema registry client" do
         expect(Avromatic.build_schema_registry).not_to equal(Avromatic.build_schema_registry)
+      end
+    end
+  end
+
+  context "preregistering models" do
+    before do
+      stub_const('NestedRecord', Avromatic::Model.model(schema_name: 'test.nested_record'))
+    end
+
+    context "at the end of configure" do
+      it "registers models" do
+        described_class.configure do |config|
+          config.preregister_models = NestedRecord
+        end
+        expect(described_class.nested_models.registered?('test.nested_record')).to eql(true)
+      end
+    end
+
+    describe "#prepare!" do
+      before do
+        stub_const('ValueModel', Avromatic::Model.model(schema_name: 'test.value'))
+      end
+
+      it "clears the registry" do
+        described_class.prepare!
+        expect(described_class.nested_models.registered?('test.value')).to eql(false)
+      end
+
+      it "registers models" do
+        described_class.preregister_models = %w(NestedRecord)
+        described_class.prepare!
+        expect(described_class.nested_models.registered?('test.value')).to eql(false)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,9 +5,9 @@ SimpleCov.start do
   add_filter 'spec'
   begin
     Gem::Specification.find_by_name('avro-salsify-fork')
-    minimum_coverage 98
-  rescue Gem::LoadError
     minimum_coverage 97
+  rescue Gem::LoadError
+    minimum_coverage 96
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,9 +5,9 @@ SimpleCov.start do
   add_filter 'spec'
   begin
     Gem::Specification.find_by_name('avro-salsify-fork')
-    minimum_coverage 97
+    minimum_coverage 98
   rescue Gem::LoadError
-    minimum_coverage 96
+    minimum_coverage 97
   end
 end
 


### PR DESCRIPTION
This change replaces the `Avromatic.on_initialize` proc with an `Avromatic.preregister_models` array that can be used to specify an array of models that are registered at the end of `.configure` and on code reloading for Rails applications.

The previous approach relied on the side-effect of a model being registered when it is defined. This was problematic for the first call to the `to_prepare` block for a Rails application because the registry would be cleared, but the constants were still defined for the models, so they would not be re-add simply by referencing. 

I considered disabling the first call to the `to_prepare` block, or disabling the clearing of the registry for the first call to the `to_prepare` block. But being explicit about registering these models seemed cleaner. The configuration could have been left as a generic proc, but that would have a call to register each of the models, so making the structure explicit and putting the registration into avromatic seemed cleaner.

Obviously this change breaks compatibility for any apps using `on_initialize`.

Prime: @jturkel 