### PR TITLE
Fix Rails initialization again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # avromatic changelog
 
+## v0.11.1
+- Another fix for Rails initialization and reloading. Do not clear the nested
+  models registry the first time that the `to_prepare` hook is called.
+
 ## v0.11.0
 - Replace `Avromatic.on_initialize` proc with `Avromatic.eager_load_models`
   array. The models listed by this configuration are added to the registry

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -42,8 +42,9 @@ module Avromatic
     self.messaging = build_messaging
   end
 
-  # This method is called as a Rails to_prepare block after the application
-  # first initializes and prior to each code reloading.
+  # This method is called as a Rails to_prepare hook after the application
+  # first initializes during boot-up and prior to each code reloading.
+  # For the first call during boot-up we do not want to clear the nested_models.
   def self.prepare!(skip_clear: false)
     nested_models.clear unless skip_clear
     eager_load_models!

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -44,8 +44,8 @@ module Avromatic
 
   # This method is called as a Rails to_prepare block after the application
   # first initializes and prior to each code reloading.
-  def self.prepare!
-    nested_models.clear
+  def self.prepare!(skip_clear: false)
+    nested_models.clear unless skip_clear
     eager_load_models!
   end
 

--- a/lib/avromatic/railtie.rb
+++ b/lib/avromatic/railtie.rb
@@ -5,6 +5,14 @@ module Avromatic
         config.logger = Rails.logger
       end
 
+      # Rails calls the to_prepare hook once during boot-up, after running
+      # initializers. After the to_prepare call during boot-up, no code will
+      # we reloaded, so we need to retain the contents of the nested_models
+      # registry.
+      #
+      # For subsequent calls to to_prepare (in development), the nested_models
+      # registry is cleared and repopulated by explicitly referencing the
+      # eager_loaded_models.
       first_prepare = true
 
       Rails.configuration.to_prepare do

--- a/lib/avromatic/railtie.rb
+++ b/lib/avromatic/railtie.rb
@@ -5,8 +5,11 @@ module Avromatic
         config.logger = Rails.logger
       end
 
+      first_prepare = true
+
       Rails.configuration.to_prepare do
-        Avromatic.prepare!
+        Avromatic.prepare!(skip_clear: first_prepare)
+        first_prepare = false
       end
     end
   end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.11.0'.freeze
+  VERSION = '0.11.1.rc0'.freeze
 end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.11.1.rc0'.freeze
+  VERSION = '0.11.1'.freeze
 end

--- a/spec/avromatic_spec.rb
+++ b/spec/avromatic_spec.rb
@@ -58,6 +58,13 @@ describe Avromatic do
         expect(described_class.nested_models.registered?('test.value')).to eql(false)
       end
 
+      context "when skip_clear is true" do
+        it "does not clear the registry" do
+          described_class.prepare!(skip_clear: true)
+          expect(described_class.nested_models.registered?('test.value')).to eql(true)
+        end
+      end
+
       it "registers models" do
         described_class.eager_load_models = %w(NestedRecord)
         described_class.prepare!


### PR DESCRIPTION
This change is part of how I originally considered fixing the initialization issues with Rails. Since no code reloading happens between initialize and the first call to `to_prepare` do not clear the nested models registry on the first call.

Prime: @jturkel 