### PR TITLE
Fix for optional array and map fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## v0.11.2
+- Fix for models containing optional array and map fields.
+
 ## v0.11.1
 - Another fix for Rails initialization and reloading. Do not clear the nested
   models registry the first time that the `to_prepare` hook is called.

--- a/lib/avromatic/model/type_registry.rb
+++ b/lib/avromatic/model/type_registry.rb
@@ -39,6 +39,9 @@ module Avromatic
 
       attr_reader :custom_types
 
+      # The type that is used to define a Virtus attribute may be a Class or
+      # for an array or map field it may be an instance of an Array or Hash.
+      # This method safely checks if a Union class has been selected.
       def union_attribute?(attribute_type)
         attribute_type.is_a?(Class) && attribute_type < Avromatic::Model::AttributeType::Union
       end

--- a/lib/avromatic/model/type_registry.rb
+++ b/lib/avromatic/model/type_registry.rb
@@ -27,7 +27,7 @@ module Avromatic
       def fetch(object, field_class = nil)
         field_type = object.is_a?(Avro::Schema::Field) ? object.type : object
 
-        if field_class && field_type.type_sym == :union && !(field_class < Avromatic::Model::AttributeType::Union)
+        if field_class && field_type.type_sym == :union && !union_attribute?(field_class)
           field_type = Avromatic::Model::Attributes.first_union_schema(field_type)
         end
 
@@ -38,6 +38,10 @@ module Avromatic
       private
 
       attr_reader :custom_types
+
+      def union_attribute?(attribute_type)
+        attribute_type.is_a?(Class) && attribute_type < Avromatic::Model::AttributeType::Union
+      end
     end
   end
 end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.11.1'.freeze
+  VERSION = '0.11.2'.freeze
 end

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -101,6 +101,32 @@ describe Avromatic::Model::Builder do
       it_behaves_like 'a generated model'
     end
 
+    context "with an optional array" do
+      let(:schema) do
+        Avro::Builder.build_schema do
+          record :with_optional_array do
+            optional :maybe_array, array(:string)
+          end
+        end
+      end
+      let(:test_class) { Avromatic::Model.model(schema: schema) }
+
+      it_behaves_like 'a generated model'
+    end
+
+    context "with an optional map" do
+      let(:schema) do
+        Avro::Builder.build_schema do
+          record :with_optional_map do
+            optional :maybe_map, map(:int)
+          end
+        end
+      end
+      let(:test_class) { Avromatic::Model.model(schema: schema) }
+
+      it_behaves_like 'a generated model'
+    end
+
     context "with a map" do
       let(:schema_name) { 'test.with_map' }
 


### PR DESCRIPTION
The "class" that is used for Virtus attributes is not always a Class. For arrays and maps it will be an instance of an Array or Hash. This change avoids performing undefined checks on those values.

Prime: @jturkel 