### PR TITLE
Clear schema store before code reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # avromatic changelog
 
+## v0.12.0
+- Clear the schema store, if it supports it, prior to code reloading in Rails
+  applications. This allows schema changes to be picked up during code
+  reloading.
+
 ## v0.11.2
 - Fix for models containing optional array and map fields.
 

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -46,7 +46,10 @@ module Avromatic
   # first initializes during boot-up and prior to each code reloading.
   # For the first call during boot-up we do not want to clear the nested_models.
   def self.prepare!(skip_clear: false)
-    nested_models.clear unless skip_clear
+    unless skip_clear
+      nested_models.clear
+      schema_store.public_send(:clear) if schema_store && schema_store.respond_to?(:clear)
+    end
     eager_load_models!
   end
 

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.11.2'.freeze
+  VERSION = '0.12.0'.freeze
 end

--- a/spec/avromatic_spec.rb
+++ b/spec/avromatic_spec.rb
@@ -51,6 +51,7 @@ describe Avromatic do
     describe "#prepare!" do
       before do
         stub_const('ValueModel', Avromatic::Model.model(schema_name: 'test.value'))
+        allow(Avromatic.schema_store).to receive(:clear)
       end
 
       it "clears the registry" do
@@ -58,10 +59,20 @@ describe Avromatic do
         expect(described_class.nested_models.registered?('test.value')).to be(false)
       end
 
+      it "clears the schema store" do
+        described_class.prepare!
+        expect(Avromatic.schema_store).to have_received(:clear)
+      end
+
       context "when skip_clear is true" do
+        before { described_class.prepare!(skip_clear: true) }
+
         it "does not clear the registry" do
-          described_class.prepare!(skip_clear: true)
           expect(described_class.nested_models.registered?('test.value')).to be(true)
+        end
+
+        it "does not clear the schema store" do
+          expect(Avromatic.schema_store).not_to have_received(:clear)
         end
       end
 


### PR DESCRIPTION
Clear the schema store used by Avromatic if the implementation supports it.

Prime: @jturkel 