### PR TITLE
Add interfaces to deserialize as a hash of model attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## v0.13.0
+- Add interfaces to deserialize as a hash of attributes instead of a model.
+
 ## v0.12.0
 - Clear the schema store, if it supports it, prior to code reloading in Rails
   applications. This allows schema changes to be picked up during code

--- a/lib/avromatic/model/messaging_serialization.rb
+++ b/lib/avromatic/model/messaging_serialization.rb
@@ -38,13 +38,17 @@ module Avromatic
         # message key and the second is the message value. If there is only one
         # arg then it is used as the message value.
         def avro_message_decode(*args)
+          new(avro_message_attributes(*args))
+        end
+
+        def avro_message_attributes(*args)
           message_key, message_value = args.size > 1 ? args : [nil, args.first]
           key_attributes = message_key &&
             avro_messaging.decode(message_key, schema_name: key_avro_schema.fullname)
           value_attributes = avro_messaging
             .decode(message_value, schema_name: avro_schema.fullname)
 
-          new(value_attributes.merge!(key_attributes || {}))
+          value_attributes.merge!(key_attributes || {})
         end
       end
 

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.12.0'.freeze
+  VERSION = '0.13.0.rc0'.freeze
 end

--- a/spec/avromatic/model/messaging_serialization_spec.rb
+++ b/spec/avromatic/model/messaging_serialization_spec.rb
@@ -170,6 +170,34 @@ describe Avromatic::Model::MessagingSerialization do
     end
   end
 
+  describe ".avro_message_attributes" do
+    let(:test_class) do
+      Avromatic::Model.model(value_schema_name: 'test.encode_value')
+    end
+    let(:values) { { str1: 'a', str2: 'b' } }
+    let(:attributes) { values.stringify_keys }
+
+    it "deserializes attributes for a model" do
+      decoded = test_class.avro_message_attributes(avro_message_value)
+      expect(decoded).to eq(attributes)
+    end
+
+    context "when a value and a key are specified" do
+      let(:test_class) do
+        Avromatic::Model.model(
+          value_schema_name: 'test.encode_value',
+          key_schema_name: 'test.encode_key'
+        )
+      end
+      let(:values) { { id: rand(99), str1: 'a', str2: 'b' } }
+
+      it "deserializes attributes for a model" do
+        decoded = test_class.avro_message_attributes(avro_message_key, avro_message_value)
+        expect(decoded).to eq(attributes)
+      end
+    end
+  end
+
   it_behaves_like "logical type encoding and decoding" do
     let(:encoded_value) { instance.avro_message_value }
     let(:decoded) { test_class.avro_message_decode(encoded_value) }


### PR DESCRIPTION
This change exposes the hash of attributes prior to building a model during deserialization.

Prime: @jturkel 