### PR TITLE
Optimize union assignment when building models from Avro messages

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,17 +1,17 @@
 appraise 'rails4_1' do
   gem 'avro', '1.8.1'
-  gem 'activesupport', '~> 4.1.15'
-  gem 'activemodel', '~> 4.1.15'
+  gem 'activesupport', '~> 4.1.16'
+  gem 'activemodel', '~> 4.1.16'
 end
 
 appraise 'rails4_2' do
   gem 'avro', '1.8.1'
-  gem 'activesupport', '~> 4.2.6'
-  gem 'activemodel', '~> 4.2.6'  
+  gem 'activesupport', '~> 4.2.7.1'
+  gem 'activemodel', '~> 4.2.7.1'
 end
 
 appraise 'avro-salsify-fork' do
-  gem 'avro-salsify-fork', '1.9.0.1', require: 'avro'
-  gem 'activesupport', '~> 4.2.6'
-  gem 'activemodel', '~> 4.2.6'
+  gem 'avro-salsify-fork', '1.9.0.3', require: 'avro'
+  gem 'activesupport', '~> 4.2.7.1'
+  gem 'activemodel', '~> 4.2.7.1'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # avromatic changelog
 
+## v0.14.0
+- Add `Avromatic::Messaging` and `Avromatic::IO::DatumReader` classes to
+  optimize the decoding of Avro unions to Avromatic models.
+
 ## v0.13.0
 - Add interfaces to deserialize as a hash of attributes instead of a model.
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ and the [Messaging API](#messaging-api).
 * **registry_url**: URL for the schema registry. Either `schema_registry` or 
   `registry_url` must be configured.
 * **messaging**: An `AvroTurf::Messaging` object to be shared by all generated models.
-  The `build_messaging!` method may be used to create a `Messaging` instance based
-  on the other configuration values.
+  The `build_messaging!` method may be used to create a `Avromatic::Messaging`
+  instance based on the other configuration values.
 * **logger**: The logger to use for the schema registry client.
 * [Custom Types](#custom-types)
 
@@ -73,6 +73,15 @@ Avromatic.configure do |config|
   config.build_messaging!
 end
 ```
+
+#### Decoding
+
+* **use_custom_datum_reader**: `Avromatic` includes a modified subclass of
+  `Avro::IO::DatumReader`. This subclass returns additional information about
+  the index of union members when decoding Avro messages. This information is
+  used to optimize model creation when decoding. By default this information
+  is included in the hash returned by the `DatumReader` but can be omitted by
+  setting this option to `false`.
 
 ### Models
 

--- a/gemfiles/avro_salsify_fork.gemfile
+++ b/gemfiles/avro_salsify_fork.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "avro-salsify-fork", "1.9.0.1", :require => "avro"
-gem "activesupport", "~> 4.2.6"
-gem "activemodel", "~> 4.2.6"
+gem "avro-salsify-fork", "1.9.0.3", :require => "avro"
+gem "activesupport", "~> 4.2.7.1"
+gem "activemodel", "~> 4.2.7.1"
 
 gemspec :path => "../"

--- a/gemfiles/rails4_1.gemfile
+++ b/gemfiles/rails4_1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "avro", "1.8.1"
-gem "activesupport", "~> 4.1.15"
-gem "activemodel", "~> 4.1.15"
+gem "activesupport", "~> 4.1.16"
+gem "activemodel", "~> 4.1.16"
 
 gemspec :path => "../"

--- a/gemfiles/rails4_2.gemfile
+++ b/gemfiles/rails4_2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "avro", "1.8.1"
-gem "activesupport", "~> 4.2.6"
-gem "activemodel", "~> 4.2.6"
+gem "activesupport", "~> 4.2.7.1"
+gem "activemodel", "~> 4.2.7.1"
 
 gemspec :path => "../"

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -1,14 +1,15 @@
 require 'avromatic/version'
+require 'avro_turf'
 require 'avromatic/model'
 require 'avromatic/model_registry'
-require 'avro_turf'
-require 'avro_turf/messaging'
+require 'avromatic/messaging'
 require 'active_support/core_ext/string/inflections'
 
 module Avromatic
   class << self
     attr_accessor :schema_registry, :registry_url, :schema_store, :logger,
-                  :messaging, :type_registry, :nested_models
+                  :messaging, :type_registry, :nested_models,
+                  :use_custom_datum_reader
 
     delegate :register_type, to: :type_registry
   end
@@ -16,6 +17,7 @@ module Avromatic
   self.nested_models = ModelRegistry.new
   self.logger = Logger.new($stdout)
   self.type_registry = Avromatic::Model::TypeRegistry.new
+  self.use_custom_datum_reader = true
 
   def self.configure
     yield self
@@ -31,7 +33,7 @@ module Avromatic
 
   def self.build_messaging
     raise 'Avromatic must be configured with a schema_store' unless schema_store
-    AvroTurf::Messaging.new(
+    Avromatic::Messaging.new(
       registry: schema_registry || build_schema_registry,
       schema_store: schema_store,
       logger: logger

--- a/lib/avromatic/io/datum_reader.rb
+++ b/lib/avromatic/io/datum_reader.rb
@@ -1,0 +1,74 @@
+# rubocop:disable Style/WhenThen
+module Avromatic
+  module IO
+    # Subclass DatumReader to include additional information about the union
+    # index used.
+    class DatumReader < Avro::IO::DatumReader
+
+      UNION_MEMBER_INDEX = '__avromatic_member_index'.freeze
+
+      def read_data(writers_schema, readers_schema, decoder, initial_record = {})
+        # schema matching
+        unless self.class.match_schemas(writers_schema, readers_schema)
+          raise SchemaMatchException.new(writers_schema, readers_schema)
+        end
+
+        # schema resolution: reader's schema is a union, writer's schema is not
+        if writers_schema.type_sym != :union && readers_schema.type_sym == :union
+          rs_index = readers_schema.schemas.find_index do |s|
+            self.class.match_schemas(writers_schema, s)
+          end
+
+          union_info = { UNION_MEMBER_INDEX => rs_index }
+
+          return read_data(writers_schema, readers_schema.schemas[rs_index], decoder, union_info) if rs_index
+          raise SchemaMatchException.new(writers_schema, readers_schema)
+        end
+
+        # function dispatch for reading data based on type of writer's
+        # schema
+        datum = case writers_schema.type_sym
+                when :null;    decoder.read_null
+                when :boolean; decoder.read_boolean
+                when :string;  decoder.read_string
+                when :int;     decoder.read_int
+                when :long;    decoder.read_long
+                when :float;   decoder.read_float
+                when :double;  decoder.read_double
+                when :bytes;   decoder.read_bytes
+                when :fixed;   read_fixed(writers_schema, readers_schema, decoder)
+                when :enum;    read_enum(writers_schema, readers_schema, decoder)
+                when :array;   read_array(writers_schema, readers_schema, decoder)
+                when :map;     read_map(writers_schema, readers_schema, decoder)
+                when :union;   read_union(writers_schema, readers_schema, decoder)
+                when :record, :error, :request; read_record(writers_schema, readers_schema, decoder, initial_record)
+                else
+                  raise AvroError.new("Cannot read unknown schema type: #{writers_schema.type}")
+                end
+
+        if readers_schema.respond_to?(:logical_type)
+          readers_schema.type_adapter.decode(datum)
+        else
+          datum
+        end
+      end
+
+      # Override to specify initial record that may contain union index
+      def read_record(writers_schema, readers_schema, decoder, initial_record = {})
+        readers_fields_hash = readers_schema.fields_hash
+        read_record = Avromatic.use_custom_datum_reader ? initial_record : {}
+        writers_schema.fields.each do |field|
+          readers_field = readers_fields_hash[field.name]
+          if readers_field
+            field_val = read_data(field.type, readers_field.type, decoder)
+            read_record[field.name] = field_val
+          else
+            skip_data(field.type, decoder)
+          end
+        end
+
+        read_record
+      end
+    end
+  end
+end

--- a/lib/avromatic/io/datum_reader.rb
+++ b/lib/avromatic/io/datum_reader.rb
@@ -2,7 +2,8 @@
 module Avromatic
   module IO
     # Subclass DatumReader to include additional information about the union
-    # index used.
+    # member index used. The code modified below is based on salsify/avro,
+    # branch 'salsify-master' with the tag 'v1.9.0.3'
     class DatumReader < Avro::IO::DatumReader
 
       UNION_MEMBER_INDEX = '__avromatic_member_index'.freeze
@@ -25,8 +26,7 @@ module Avromatic
           raise SchemaMatchException.new(writers_schema, readers_schema)
         end
 
-        # function dispatch for reading data based on type of writer's
-        # schema
+        # function dispatch for reading data based on type of writer's schema
         datum = case writers_schema.type_sym
                 when :null;    decoder.read_null
                 when :boolean; decoder.read_boolean
@@ -46,6 +46,8 @@ module Avromatic
                   raise AvroError.new("Cannot read unknown schema type: #{writers_schema.type}")
                 end
 
+        # Allow this code to be used with an official Avro release or the
+        # avro-salsify-fork that includes logical_type support.
         if readers_schema.respond_to?(:logical_type)
           readers_schema.type_adapter.decode(datum)
         else
@@ -53,7 +55,7 @@ module Avromatic
         end
       end
 
-      # Override to specify initial record that may contain union index
+      # Override to specify an initial record that may contain union index
       def read_record(writers_schema, readers_schema, decoder, initial_record = {})
         readers_fields_hash = readers_schema.fields_hash
         read_record = Avromatic.use_custom_datum_reader ? initial_record : {}

--- a/lib/avromatic/messaging.rb
+++ b/lib/avromatic/messaging.rb
@@ -2,7 +2,7 @@ require 'avro_turf/messaging'
 require 'avromatic/io/datum_reader'
 
 module Avromatic
-  # Subclass AvroTurf::Messaging to use a custom DatumReader
+  # Subclass AvroTurf::Messaging to use a custom DatumReader for decode.
   class Messaging < AvroTurf::Messaging
     def decode(data, schema_name: nil, namespace: @namespace)
       readers_schema = schema_name && @schema_store.find(schema_name, namespace)
@@ -24,7 +24,7 @@ module Avromatic
         @schemas_by_id[schema_id] = Avro::Schema.parse(schema_json)
       end
 
-      # The following line was changed to use a custom DatumReader
+      # The following line differs from the parent class to use a custom DatumReader
       reader = Avromatic::IO::DatumReader.new(writers_schema, readers_schema)
       reader.read(decoder)
     end

--- a/lib/avromatic/messaging.rb
+++ b/lib/avromatic/messaging.rb
@@ -1,0 +1,32 @@
+require 'avro_turf/messaging'
+require 'avromatic/io/datum_reader'
+
+module Avromatic
+  # Subclass AvroTurf::Messaging to use a custom DatumReader
+  class Messaging < AvroTurf::Messaging
+    def decode(data, schema_name: nil, namespace: @namespace)
+      readers_schema = schema_name && @schema_store.find(schema_name, namespace)
+      stream = StringIO.new(data)
+      decoder = Avro::IO::BinaryDecoder.new(stream)
+
+      # The first byte is MAGIC!!!
+      magic_byte = decoder.read(1)
+
+      if magic_byte != MAGIC_BYTE
+        raise "Expected data to begin with a magic byte, got `#{magic_byte.inspect}`"
+      end
+
+      # The schema id is a 4-byte big-endian integer.
+      schema_id = decoder.read(4).unpack('N').first
+
+      writers_schema = @schemas_by_id.fetch(schema_id) do
+        schema_json = @registry.fetch(schema_id)
+        @schemas_by_id[schema_id] = Avro::Schema.parse(schema_json)
+      end
+
+      # The following line was changed to use a custom DatumReader
+      reader = Avromatic::IO::DatumReader.new(writers_schema, readers_schema)
+      reader.read(decoder)
+    end
+  end
+end

--- a/lib/avromatic/model/attribute/union.rb
+++ b/lib/avromatic/model/attribute/union.rb
@@ -27,7 +27,7 @@ module Avromatic
           return input if value_coerced?(input)
 
           result = nil
-          if input.key?(MEMBER_INDEX)
+          if input && input.key?(MEMBER_INDEX)
             result = safe_coerce(member_attributes[input.delete(MEMBER_INDEX)], input)
           else
             member_attributes.find do |union_attribute|

--- a/lib/avromatic/model/attribute/union.rb
+++ b/lib/avromatic/model/attribute/union.rb
@@ -1,4 +1,5 @@
 require 'avromatic/model/attribute_type/union'
+require 'avromatic/io/datum_reader'
 
 module Avromatic
   module Model
@@ -12,6 +13,8 @@ module Avromatic
       class Union < Virtus::Attribute
         primitive Avromatic::Model::AttributeType::Union
 
+        MEMBER_INDEX = ::Avromatic::IO::DatumReader::UNION_MEMBER_INDEX
+
         def initialize(*)
           super
 
@@ -24,12 +27,11 @@ module Avromatic
           return input if value_coerced?(input)
 
           result = nil
-          member_attributes.find do |union_attribute|
-            begin
-              coerced = union_attribute.coerce(input)
-              result = coerced unless coerced.is_a?(Avromatic::Model::Attributes) && coerced.invalid?
-            rescue
-              nil
+          if input.key?(MEMBER_INDEX)
+            result = safe_coerce(member_attributes[input.delete(MEMBER_INDEX)], input)
+          else
+            member_attributes.find do |union_attribute|
+              result = safe_coerce(union_attribute, input)
             end
           end
           result
@@ -42,6 +44,13 @@ module Avromatic
         end
 
         private
+
+        def safe_coerce(member_attribute, input)
+          coerced = member_attribute.coerce(input)
+          coerced unless coerced.is_a?(Avromatic::Model::Attributes) && coerced.invalid?
+        rescue
+          nil
+        end
 
         def member_attributes
           @member_attributes ||= Array.new

--- a/lib/avromatic/model/messaging_serialization.rb
+++ b/lib/avromatic/model/messaging_serialization.rb
@@ -1,5 +1,3 @@
-require 'avro_turf/messaging'
-
 module Avromatic
   module Model
 

--- a/lib/avromatic/model/raw_serialization.rb
+++ b/lib/avromatic/model/raw_serialization.rb
@@ -88,11 +88,14 @@ module Avromatic
         end
 
         def custom_datum_reader(schema, key_or_value)
-          Avro::IO::DatumReader.new(schema, send("#{key_or_value}_avro_schema"))
+          datum_reader_class.new(schema, send("#{key_or_value}_avro_schema"))
         end
       end
 
       module ClassMethods
+        def datum_reader_class
+          Avromatic::IO::DatumReader
+        end
 
         # Store a hash of Procs by field name (as a symbol) to convert
         # the value before Avro serialization.
@@ -111,8 +114,8 @@ module Avromatic
 
         def datum_reader
           @datum_reader ||= begin
-            hash = { value: Avro::IO::DatumReader.new(value_avro_schema) }
-            hash[:key] = Avro::IO::DatumReader.new(key_avro_schema) if key_avro_schema
+            hash = { value: datum_reader_class.new(value_avro_schema) }
+            hash[:key] = datum_reader_class.new(key_avro_schema) if key_avro_schema
             hash
           end
         end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.13.0'.freeze
+  VERSION = '0.14.0.rc0'.freeze
 end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.14.0.rc0'.freeze
+  VERSION = '0.14.0.rc1'.freeze
 end

--- a/spec/avromatic/io/datum_reader_spec.rb
+++ b/spec/avromatic/io/datum_reader_spec.rb
@@ -1,0 +1,53 @@
+describe Avromatic::IO::DatumReader do
+  let(:test_class) do
+    Avromatic::Model.model(schema_name: schema_name)
+  end
+  let(:instance) { test_class.new(values) }
+  let(:avro_message_value) { instance.avro_message_value }
+  let(:attributes) { test_class.avro_message_attributes(avro_message_value) }
+
+  context "primitive types" do
+    let(:schema_name) { 'test.primitive_types' }
+    let(:values) do
+      {
+        s: 'foo',
+        b: '123',
+        tf: true,
+        i: rand(10),
+        l: 123456789,
+        f: 0.5,
+        d: 1.0 / 3.0,
+        n: nil
+      }
+    end
+
+    # This test case is primarily to provide coverage for DatumReader
+    it "reads all primitive types" do
+      expect(attributes).to eq(values.stringify_keys)
+    end
+  end
+
+  context "a record with a union" do
+    let(:schema_name) { 'test.real_union' }
+    let(:values) do
+      {
+        header: 'has bar',
+        message: { bar_message: "I'm a bar" }
+      }
+    end
+
+    it "includes the member index in the decoded hash" do
+      expect(attributes['message'][described_class::UNION_MEMBER_INDEX]).to eq(1)
+    end
+
+    context "when use_custom_datum_reader is false" do
+      before do
+        allow(Avromatic).to receive(:use_custom_datum_reader).and_return(false)
+      end
+
+      it "includes the member index in the decoded hash" do
+        expect(attributes['message']).not_to have_key(described_class::UNION_MEMBER_INDEX)
+      end
+    end
+  end
+end

--- a/spec/avromatic/io/datum_reader_spec.rb
+++ b/spec/avromatic/io/datum_reader_spec.rb
@@ -45,7 +45,7 @@ describe Avromatic::IO::DatumReader do
         allow(Avromatic).to receive(:use_custom_datum_reader).and_return(false)
       end
 
-      it "includes the member index in the decoded hash" do
+      it "does not include the member index in the decoded hash" do
         expect(attributes['message']).not_to have_key(described_class::UNION_MEMBER_INDEX)
       end
     end

--- a/spec/avromatic/model/raw_serialization_spec.rb
+++ b/spec/avromatic/model/raw_serialization_spec.rb
@@ -160,7 +160,7 @@ describe Avromatic::Model::RawSerialization do
       end
     end
 
-    context "array of pre-registed nested models" do
+    context "array of pre-registered nested models" do
       let(:nested_schema) do
         Avro::Builder.build_schema do
           record :int_rec do


### PR DESCRIPTION
This change introduces `Avromatic` subclasses for `AvroTurf::Messaging` and `Avro::IO::DatumReader`. `Avromatic::Messaging` uses the new `Avromatic::IO::DatumReader` to read Avro messages.

`Avromatic::IO::DatumReader` changes the behavior of the standard `DatumReader` to include an additional entry in the hash returned for a record giving the index of corresponding union member.

The `Avromatic` code for assigning to union attributes makes use of this additional member index information if present.

In testing with one of our more complex schemas, this makes model building with unions more than 2x faster.

A new configuration option, `use_custom_datum_reader`, is included and defaults to true. This can be set to false to disable the optimization and the additional entry returned by the `DatumReader`.

Also included here are some updates to the versions of gems that we test against using Appraisals.

Prime: @will89  