### PR TITLE
Add support for looking up schema by fingerprint before registering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # avromatic changelog
 
+## v0.15.0
+- Add patch to `AvroTurf::SchemaRegistry` to lookup existing schema ids using
+  `GET /subjects/:subject/fingerprints/:fingerprint` from `#register`.
+  This endpoint is supported in the avro-schema-registry.
+- Add patch to the `FakeSchemaRegistryServer` from `AvroTurf` to support the
+  fingerprint endpoint.
+
 ## v0.14.0
 - Add `Avromatic::Messaging` and `Avromatic::IO::DatumReader` classes to
   optimize the decoding of Avro unions to Avromatic models.

--- a/lib/avromatic/model/message_decoder.rb
+++ b/lib/avromatic/model/message_decoder.rb
@@ -1,4 +1,4 @@
-require 'avro_turf/schema_registry'
+require 'avromatic/schema_registry_patch'
 
 module Avromatic
   module Model

--- a/lib/avromatic/rspec.rb
+++ b/lib/avromatic/rspec.rb
@@ -1,5 +1,5 @@
 require 'webmock/rspec'
-require 'avro_turf/test/fake_schema_registry_server'
+require 'avromatic/test/fake_schema_registry_server'
 
 RSpec.configure do |config|
   config.before(:each) do

--- a/lib/avromatic/schema_registry_patch.rb
+++ b/lib/avromatic/schema_registry_patch.rb
@@ -1,0 +1,23 @@
+require 'avro_turf'
+require 'avro_turf/schema_registry'
+
+AvroTurf::SchemaRegistry.class_eval do
+  # Override register to first check if a schema is registered by fingerprint
+  def register(subject, schema)
+    raise 'schema must be an Avro::Schema' unless schema.is_a?(Avro::Schema)
+
+    registered = false
+    data = begin
+             get("/subjects/#{subject}/fingerprints/#{schema.sha256_fingerprint.to_s(16)}")
+           rescue
+             registered = true
+             post("/subjects/#{subject}/versions", body: { schema: schema.to_s }.to_json)
+           end
+
+    id = data.fetch('id')
+
+    @logger.info("#{registered ? 'Registered' : 'Found'} schema for subject `#{subject}`; id = #{id}")
+
+    id
+  end
+end

--- a/lib/avromatic/schema_registry_patch.rb
+++ b/lib/avromatic/schema_registry_patch.rb
@@ -4,11 +4,15 @@ require 'avro_turf/schema_registry'
 AvroTurf::SchemaRegistry.class_eval do
   # Override register to first check if a schema is registered by fingerprint
   def register(subject, schema)
-    raise 'schema must be an Avro::Schema' unless schema.is_a?(Avro::Schema)
+    schema_object = if schema.is_a?(String)
+                      Avro::Schema.parse(schema)
+                    else
+                      schema
+                    end
 
     registered = false
     data = begin
-             get("/subjects/#{subject}/fingerprints/#{schema.sha256_fingerprint.to_s(16)}")
+             get("/subjects/#{subject}/fingerprints/#{schema_object.sha256_fingerprint.to_s(16)}")
            rescue
              registered = true
              post("/subjects/#{subject}/versions", body: { schema: schema.to_s }.to_json)

--- a/lib/avromatic/test/fake_schema_registry_server.rb
+++ b/lib/avromatic/test/fake_schema_registry_server.rb
@@ -1,0 +1,24 @@
+require 'avro_turf/test/fake_schema_registry_server'
+
+# Add support for endpoint to lookup subject schema id by fingerprint.
+FakeSchemaRegistryServer.class_eval do
+  SCHEMA_NOT_FOUND = FakeSchemaRegistryServer::SCHEMA_NOT_FOUND
+  SCHEMAS = FakeSchemaRegistryServer::SCHEMAS
+  SUBJECTS = FakeSchemaRegistryServer::SUBJECTS
+
+  get '/subjects/:subject/fingerprints/:fingerprint' do
+    subject = params[:subject]
+    halt(404, SCHEMA_NOT_FOUND) unless SUBJECTS.key?(subject)
+
+    fingerprint = params[:fingerprint]
+    fingerprint = fingerprint.to_i.to_s(16) if /^\d+$/ =~ fingerprint
+
+    schema_id = SCHEMAS.find_index do |schema|
+      Avro::Schema.parse(schema).sha256_fingerprint.to_s(16) == fingerprint
+    end
+
+    halt(404, SCHEMA_NOT_FOUND) unless schema_id && SUBJECTS[subject].include?(schema_id)
+
+    { id: schema_id }.to_json
+  end
+end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.14.0'.freeze
+  VERSION = '0.15.0.rc0'.freeze
 end

--- a/spec/avromatic/schema_registry_patch_spec.rb
+++ b/spec/avromatic/schema_registry_patch_spec.rb
@@ -1,0 +1,37 @@
+# rubocop:disable RSpec/FilePath
+
+describe AvroTurf::SchemaRegistry, 'schema registry patch' do
+  let(:logger) { Logger.new(StringIO.new) }
+  let(:subject_name) { 'some-subject' }
+  let(:schema) do
+    {
+      type: 'record',
+      name: 'person',
+      fields: [
+        { name: 'name', type: 'string' }
+      ]
+    }.to_json
+  end
+  let(:avro_schema) { Avro::Schema.parse(schema) }
+  let(:registry) { described_class.new(Avromatic.registry_url, logger: logger) }
+
+  describe "#register" do
+    it "does not allow registration of an Avro JSON schema" do
+      expect do
+        registry.register(subject_name, schema)
+      end.to raise_error('schema must be an Avro::Schema')
+    end
+
+    it "allows the registration of an Avro::Schema" do
+      id = registry.register(subject_name, avro_schema)
+      expect(registry.fetch(id)).to eq(avro_schema.to_s)
+    end
+
+    it "makes a request to check if the schema exists before attempting to register" do
+      id = registry.register(subject_name, avro_schema)
+      allow(FakeSchemaRegistryServer).to receive(:post)
+      expect(registry.register(subject_name, avro_schema)).to eq(id)
+      expect(FakeSchemaRegistryServer).not_to have_received(:post)
+    end
+  end
+end

--- a/spec/avromatic/schema_registry_patch_spec.rb
+++ b/spec/avromatic/schema_registry_patch_spec.rb
@@ -16,10 +16,9 @@ describe AvroTurf::SchemaRegistry, 'schema registry patch' do
   let(:registry) { described_class.new(Avromatic.registry_url, logger: logger) }
 
   describe "#register" do
-    it "does not allow registration of an Avro JSON schema" do
-      expect do
-        registry.register(subject_name, schema)
-      end.to raise_error('schema must be an Avro::Schema')
+    it "allows registration of an Avro JSON schema" do
+      id = registry.register(subject_name, schema)
+      expect(registry.fetch(id)).to eq(avro_schema.to_s)
     end
 
     it "allows the registration of an Avro::Schema" do


### PR DESCRIPTION
This change adds patch for `AvroTurf::SchemaRegistry` and `FakeSchemaRegistryServer` (both from `AvroTurf`) to support the `GET /subjects/:subject/fingerprints/:fingerprint` endpoint that is used to lookup schemas prior to registering.

Patching these classes seemed like the least intrusive way to add this support. By modifying the `SchemaRegistry` client, the `Messaging` API does not need to be touched.

All of our applications that use Avro use this gem, so they will automatically pick up this additional functionality, and tests use the fake server via `avromatic/rspec` which is updated here to pull in the patched version.

Prime: @will89 