### PR TITLE
Refactor to expose AvroTurf::SchemaRegistry#lookup_subject_schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # avromatic changelog
 
+## v0.16.0
+- Add `#lookup_subject_schema` method to `AvroTurf::SchemaRegistry` patch to
+  directly support looking up existing schema ids by fingerprint.
+
 ## v0.15.1
 - Add `Avromatic.use_cacheable_schema_registration` option to control the lookup
   of existing schema ids by fingerprint.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ and the [Messaging API](#messaging-api).
   The use of this additional endpoint can be disabled by setting this option to
   `false` and this is recommended if using a Schema Registry that does not support
   the endpoint.
-* **messaging**: An `AvroTurf::Messaging` object to be shared by all generated models.
+* **messaging**: An `AvroTurf::Messaging` object to be shared by all generated models
   The `build_messaging!` method may be used to create a `Avromatic::Messaging`
   instance based on the other configuration values.
 * **logger**: The logger to use for the schema registry client.

--- a/lib/avromatic/schema_registry_patch.rb
+++ b/lib/avromatic/schema_registry_patch.rb
@@ -9,7 +9,7 @@ module Avromatic
 
       begin
         lookup_subject_schema(subject, schema)
-      rescue
+      rescue Excon::Errors::NotFound
         data = post("/subjects/#{subject}/versions", body: { schema: schema.to_s }.to_json)
         id = data.fetch('id')
         @logger.info("Registered schema for subject `#{subject}`; id = #{id}")

--- a/lib/avromatic/schema_registry_patch.rb
+++ b/lib/avromatic/schema_registry_patch.rb
@@ -7,24 +7,26 @@ module Avromatic
     def register(subject, schema)
       return super unless Avromatic.use_cacheable_schema_registration
 
+      begin
+        lookup_subject_schema(subject, schema)
+      rescue
+        data = post("/subjects/#{subject}/versions", body: { schema: schema.to_s }.to_json)
+        id = data.fetch('id')
+        @logger.info("Registered schema for subject `#{subject}`; id = #{id}")
+        id
+      end
+    end
+
+    def lookup_subject_schema(subject, schema)
       schema_object = if schema.is_a?(String)
                         Avro::Schema.parse(schema)
                       else
                         schema
                       end
 
-      registered = false
-      data = begin
-        get("/subjects/#{subject}/fingerprints/#{schema_object.sha256_fingerprint.to_s(16)}")
-      rescue
-        registered = true
-        post("/subjects/#{subject}/versions", body: { schema: schema.to_s }.to_json)
-      end
-
+      data = get("/subjects/#{subject}/fingerprints/#{schema_object.sha256_fingerprint.to_s(16)}")
       id = data.fetch('id')
-
-      @logger.info("#{registered ? 'Registered' : 'Found'} schema for subject `#{subject}`; id = #{id}")
-
+      @logger.info("Found schema for subject `#{subject}`; id = #{id}")
       id
     end
   end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.15.1'.freeze
+  VERSION = '0.16.0'.freeze
 end

--- a/spec/avromatic/schema_registry_patch_spec.rb
+++ b/spec/avromatic/schema_registry_patch_spec.rb
@@ -28,9 +28,9 @@ describe AvroTurf::SchemaRegistry, 'schema registry patch' do
 
     it "makes a request to check if the schema exists before attempting to register" do
       id = registry.register(subject_name, avro_schema)
-      allow(FakeSchemaRegistryServer).to receive(:post)
+      allow(registry).to receive(:post)
       expect(registry.register(subject_name, avro_schema)).to eq(id)
-      expect(FakeSchemaRegistryServer).not_to have_received(:post)
+      expect(registry).not_to have_received(:post)
     end
 
     context "when use_cacheable_schema_registration is false" do
@@ -42,6 +42,18 @@ describe AvroTurf::SchemaRegistry, 'schema registry patch' do
         allow(registry).to receive(:get).and_call_original
         registry.register(subject_name, avro_schema)
         expect(registry).not_to have_received(:get)
+      end
+    end
+
+    context "when the check prior to registration raises an error other than NotFound" do
+      before do
+        allow(registry).to receive(:get).and_raise(Excon::Errors::InternalServerError.new('error'))
+      end
+
+      it "raises the error" do
+        expect do
+          registry.register(subject_name, schema)
+        end.to raise_error(Excon::Errors::InternalServerError)
       end
     end
   end

--- a/spec/avromatic/schema_registry_patch_spec.rb
+++ b/spec/avromatic/schema_registry_patch_spec.rb
@@ -45,4 +45,26 @@ describe AvroTurf::SchemaRegistry, 'schema registry patch' do
       end
     end
   end
+
+  describe "#lookup_subject_schema" do
+    context "when the schema does not exist" do
+      it "raises an error" do
+        expect do
+          registry.lookup_subject_schema(subject_name, schema)
+        end.to raise_error(Excon::Errors::NotFound)
+      end
+    end
+
+    context "with a previously registered schema" do
+      let!(:id) { registry.register(subject_name, schema) }
+
+      it "allows lookup using an Avro JSON schema" do
+        expect(registry.lookup_subject_schema(subject_name, schema)).to eq(id)
+      end
+
+      it "allows lookup using an Avro::Schema object" do
+        expect(registry.lookup_subject_schema(subject_name, avro_schema)).to eq(id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
I thought it made sense to support the additional endpoint directly in the `SchemaRegistry` client, so this change moves things around in the patch to expose it.

Prime: @jturkel 