### PR TITLE
Add register_schemas! method to generated models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # avromatic changelog
 
+## v0.17.0
+- Add `.register_schemas!` method to generated models to register the associated
+  schemas in a schema registry.
+
 ## v0.16.0
 - Add `#lookup_subject_schema` method to `AvroTurf::SchemaRegistry` patch to
   directly support looking up existing schema ids by fingerprint.

--- a/README.md
+++ b/README.md
@@ -319,6 +319,13 @@ Or just a value if only one schema is used:
 MyValue.avro_message_decode(message_value)
 ```
 
+The schemas associated with a model can also be added to a schema registry without
+encoding a message:
+
+```ruby
+MyTopic.register_schemas!
+```
+
 #### Avromatic::Model::MessageDecoder
 
 A stream of messages encoded from various models using the messaging approach

--- a/lib/avromatic/messaging.rb
+++ b/lib/avromatic/messaging.rb
@@ -4,6 +4,8 @@ require 'avromatic/io/datum_reader'
 module Avromatic
   # Subclass AvroTurf::Messaging to use a custom DatumReader for decode.
   class Messaging < AvroTurf::Messaging
+    attr_reader :registry
+
     def decode(data, schema_name: nil, namespace: @namespace)
       readers_schema = schema_name && @schema_store.find(schema_name, namespace)
       stream = StringIO.new(data)

--- a/lib/avromatic/model/messaging_serialization.rb
+++ b/lib/avromatic/model/messaging_serialization.rb
@@ -50,6 +50,20 @@ module Avromatic
         end
       end
 
+      module Registration
+        def register_schemas!
+          register_schema(key_avro_schema) if key_avro_schema
+          register_schema(value_avro_schema)
+          nil
+        end
+
+        private
+
+        def register_schema(schema)
+          avro_messaging.registry.register(schema.fullname, schema)
+        end
+      end
+
       module ClassMethods
         # The messaging object acts as an intermediary talking to the schema
         # registry and using returned/specified schemas to decode/encode.
@@ -58,6 +72,7 @@ module Avromatic
         end
 
         include Decode
+        include Registration
       end
     end
   end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.16.0'.freeze
+  VERSION = '0.17.0'.freeze
 end

--- a/spec/avromatic/model/messaging_serialization_spec.rb
+++ b/spec/avromatic/model/messaging_serialization_spec.rb
@@ -357,4 +357,45 @@ describe Avromatic::Model::MessagingSerialization do
       end
     end
   end
+
+  describe ".register_schemas!" do
+    let(:registry) { Avromatic.build_schema_registry }
+
+    shared_examples_for "value schema registration" do
+      it "registers the value schema" do
+        expect(test_class.register_schemas!).to be_nil
+        registered = registry.subject_version(test_class.value_avro_schema.fullname)
+        aggregate_failures do
+          expect(registered['version']).to eq(1)
+          expect(registered['schema']).to eq(test_class.value_avro_schema.to_s)
+        end
+      end
+    end
+
+    context "a model without a key" do
+      let(:test_class) do
+        Avromatic::Model.model(value_schema_name: 'test.encode_value')
+      end
+
+      it_behaves_like "value schema registration"
+    end
+
+    context "a model with a key and value" do
+      let(:test_class) do
+        Avromatic::Model.model(value_schema_name: 'test.encode_value',
+                               key_schema_name: 'test.encode_key')
+      end
+
+      it_behaves_like "value schema registration"
+
+      it "registers the key schema" do
+        expect(test_class.register_schemas!).to be_nil
+        registered = registry.subject_version(test_class.key_avro_schema.fullname)
+        aggregate_failures do
+          expect(registered['version']).to eq(1)
+          expect(registered['schema']).to eq(test_class.key_avro_schema.to_s)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This method provides a convenient way to register the schemas associated with a model without needing to publish a message.

Eventually, this could be surrounded by calls that alter the compatibility level for a subject in the schema registry, if necessary. Currently the schema registry client doesn't support the Config API so I'm adding this by itself for now.

Prime: @jturkel 