### PR TITLE
Replace another reference to fake_schema_registry_server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## v0.18.1
+- Replace another reference to `avromatic/test/fake_schema_registry_server`.
+
 ## v0.18.0
 - Compatibility with `avro_turf` v0.8.0. `avromatic/test/fake_schema_registry_server`
   is now deprecated and will be removed in a future release.

--- a/lib/avromatic/rspec.rb
+++ b/lib/avromatic/rspec.rb
@@ -1,5 +1,5 @@
 require 'webmock/rspec'
-require 'avromatic/test/fake_schema_registry_server'
+require 'avromatic/test/fake_confluent_schema_registry_server'
 
 RSpec.configure do |config|
   config.before(:each) do

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.18.0'.freeze
+  VERSION = '0.18.1'.freeze
 end


### PR DESCRIPTION
After releasing this I found one more reference to the old name that I missed.

Prime: @jturkel 