### PR TITLE
Use avro-resolution_canonical_form

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -11,7 +11,7 @@ appraise 'rails4_2' do
 end
 
 appraise 'avro-salsify-fork' do
-  gem 'avro-salsify-fork', '1.9.0.3', require: 'avro'
+  gem 'avro-salsify-fork', '1.9.0.5', require: 'avro'
   gem 'activesupport', '~> 4.2.7.1'
   gem 'activemodel', '~> 4.2.7.1'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## v0.19.0
+- Use a fingerprint based on `avro-resolution_canonical_form`.
+
 ## v0.18.1
 - Replace another reference to `avromatic/test/fake_schema_registry_server`.
 

--- a/avromatic.gemspec
+++ b/avromatic.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activesupport'
   spec.add_runtime_dependency 'activemodel'
   spec.add_runtime_dependency 'avro_turf', '>= 0.8.0'
+  spec.add_runtime_dependency 'avro-resolution_canonical_form', '0.1.0.rc0'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/gemfiles/avro_salsify_fork.gemfile
+++ b/gemfiles/avro_salsify_fork.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "avro-salsify-fork", "1.9.0.3", :require => "avro"
+gem "avro-salsify-fork", "1.9.0.5", :require => "avro"
 gem "activesupport", "~> 4.2.7.1"
 gem "activemodel", "~> 4.2.7.1"
 

--- a/lib/avromatic/schema_registry_patch.rb
+++ b/lib/avromatic/schema_registry_patch.rb
@@ -1,5 +1,6 @@
 require 'avro_turf'
 require 'avro_turf/confluent_schema_registry'
+require 'avro-resolution_canonical_form'
 
 module Avromatic
   module CacheableSchemaRegistration
@@ -24,7 +25,7 @@ module Avromatic
                         schema
                       end
 
-      data = get("/subjects/#{subject}/fingerprints/#{schema_object.sha256_fingerprint.to_s(16)}")
+      data = get("/subjects/#{subject}/fingerprints/#{schema_object.sha256_resolution_fingerprint.to_s(16)}")
       id = data.fetch('id')
       @logger.info("Found schema for subject `#{subject}`; id = #{id}")
       id

--- a/lib/avromatic/test/fake_confluent_schema_registry_server.rb
+++ b/lib/avromatic/test/fake_confluent_schema_registry_server.rb
@@ -1,4 +1,5 @@
 require 'avro_turf/test/fake_confluent_schema_registry_server'
+require 'avro-resolution_canonical_form'
 
 # Add support for endpoint to lookup subject schema id by fingerprint.
 FakeConfluentSchemaRegistryServer.class_eval do
@@ -14,7 +15,7 @@ FakeConfluentSchemaRegistryServer.class_eval do
     fingerprint = fingerprint.to_i.to_s(16) if /^\d+$/ =~ fingerprint
 
     schema_id = SCHEMAS.find_index do |schema|
-      Avro::Schema.parse(schema).sha256_fingerprint.to_s(16) == fingerprint
+      Avro::Schema.parse(schema).sha256_resolution_fingerprint.to_s(16) == fingerprint
     end
 
     halt(404, SCHEMA_NOT_FOUND) unless schema_id && SUBJECTS[subject].include?(schema_id)

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.18.1'.freeze
+  VERSION = '0.19.0.rc0'.freeze
 end

--- a/spec/avromatic/schema_registry_patch_spec.rb
+++ b/spec/avromatic/schema_registry_patch_spec.rb
@@ -8,7 +8,7 @@ describe AvroTurf::ConfluentSchemaRegistry, 'schema registry patch' do
       type: 'record',
       name: 'person',
       fields: [
-        { name: 'name', type: 'string' }
+        { name: 'name', type: 'string', default: 'unknown' }
       ]
     }.to_json
   end


### PR DESCRIPTION
This updates avromatic to use a fingerprint that includes all attributes that are relevant to schema resolution and compatibility checking.

Clients cannot be updated to use this version until the avro-schema-registry has been updated.

Prime: @jturkel 