### PR TITLE
Fix optional union decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## v0.21.1
+- Fix a bug in the optimization of optional union decoding.
+
 ## v0.21.0
 - Remove monkey-patches for `AvroTurf::ConfluentSchemaRegistry` and
   `FakeConfluentSchemaRegistryServer` and depend on `avro_schema_registry-client`

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -144,6 +144,9 @@ module Avromatic
         end
 
         def union_field_class(field_type)
+          null_index = field_type.schemas.index { |schema| schema.type_sym == :null }
+          raise 'a null type in a union must be the first member' if null_index && null_index > 0
+
           field_classes = field_type.schemas.reject { |schema| schema.type_sym == :null }
                             .map { |schema| avro_field_class(schema) }
 

--- a/spec/avro/dsl/test/null_in_union.rb
+++ b/spec/avro/dsl/test/null_in_union.rb
@@ -1,0 +1,13 @@
+namespace :test
+
+record :i_rec do
+  required :i, :int
+end
+
+record :s_rec do
+  required :s, :string
+end
+
+record :null_in_union do
+  required :values, array(union(:i_rec, null, :s_rec))
+end

--- a/spec/avro/dsl/test/optional_union.rb
+++ b/spec/avro/dsl/test/optional_union.rb
@@ -1,0 +1,14 @@
+namespace :test
+
+record :foo do
+  required :foo_message, :string
+end
+
+record :bar do
+  required :bar_message, :string
+end
+
+record :optional_union do
+  required :header, :string
+  optional :message, :union, types: [:foo, :bar]
+end

--- a/spec/avro/schema/test/null_in_union.avsc
+++ b/spec/avro/schema/test/null_in_union.avsc
@@ -1,0 +1,38 @@
+{
+  "type": "record",
+  "name": "null_in_union",
+  "namespace": "test",
+  "fields": [
+    {
+      "name": "values",
+      "type": {
+        "type": "array",
+        "items": [
+          {
+            "type": "record",
+            "name": "i_rec",
+            "namespace": "test",
+            "fields": [
+              {
+                "name": "i",
+                "type": "int"
+              }
+            ]
+          },
+          "null",
+          {
+            "type": "record",
+            "name": "s_rec",
+            "namespace": "test",
+            "fields": [
+              {
+                "name": "s",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/spec/avro/schema/test/optional_union.avsc
+++ b/spec/avro/schema/test/optional_union.avsc
@@ -1,0 +1,40 @@
+{
+  "type": "record",
+  "name": "optional_union",
+  "namespace": "test",
+  "fields": [
+    {
+      "name": "header",
+      "type": "string"
+    },
+    {
+      "name": "message",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "foo",
+          "namespace": "test",
+          "fields": [
+            {
+              "name": "foo_message",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "type": "record",
+          "name": "bar",
+          "namespace": "test",
+          "fields": [
+            {
+              "name": "bar_message",
+              "type": "string"
+            }
+          ]
+        }
+      ],
+      "default": null
+    }
+  ]
+}

--- a/spec/avromatic/io/datum_reader_spec.rb
+++ b/spec/avromatic/io/datum_reader_spec.rb
@@ -32,7 +32,6 @@ describe Avromatic::IO::DatumReader do
         expect { reader.read(decoder) }.to raise_error(Avro::AvroError)
       end
     end
-
   end
 
   context "primitive types" do
@@ -67,6 +66,58 @@ describe Avromatic::IO::DatumReader do
 
     it "includes the member index in the decoded hash" do
       expect(attributes['message'][described_class::UNION_MEMBER_INDEX]).to eq(1)
+    end
+
+    it "can decode a message" do
+      expect(test_class.avro_message_decode(avro_message_value)).to eq(instance)
+    end
+
+    context "a record with an optional union" do
+      let(:schema_name) { 'test.optional_union' }
+
+      it "includes the member index in the decoded hash" do
+        puts instance.value_attributes_for_avro
+        expect(attributes['message'][described_class::UNION_MEMBER_INDEX]).to eq(1)
+      end
+
+      it "can decode a message" do
+        expect(test_class.avro_message_decode(avro_message_value)).to eq(instance)
+      end
+    end
+
+    context "with an optional field" do
+      let(:schema_name) { 'test.with_union' }
+      let(:values) { { s: 'foo' } }
+
+      it "does not include a member index in the decoded hash" do
+        expect(attributes).not_to have_key(described_class::UNION_MEMBER_INDEX)
+      end
+    end
+
+    context "with null in a union" do
+      let(:schema_name) { 'test.null_in_union' }
+      let(:values) do
+        {
+          values: [
+            { i: 123 },
+            nil,
+            { s: 'abc' }
+          ]
+        }
+      end
+
+      it "includes the member index in the decoded hash" do
+        pending "a null type in the middle of union member types is currently broken/unsupported"
+
+        expect(attributes['values'][0][described_class::UNION_MEMBER_INDEX]).to eq(0)
+        expect(attributes['values'][2][described_class::UNION_MEMBER_INDEX]).to eq(2)
+      end
+
+      it "can decode a message" do
+        pending "a null type in the middle of union member types is currently broken/unsupported"
+
+        expect(test_class.avro_message_decode(avro_message_value)).to eq(instance)
+      end
     end
 
     context "when use_custom_datum_reader is false" do

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -387,6 +387,18 @@ describe Avromatic::Model::Builder do
             .to raise_error('custom types within unions are currently unsupported')
         end
       end
+
+      context "null after the first union member type" do
+        let(:schema_name) { 'test.null_in_union' }
+        let(:test_class) do
+          described_class.model(schema_name: schema_name)
+        end
+
+        it "raises an error" do
+          expect { test_class }
+            .to raise_error('a null type in a union must be the first member')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This fixes the issue that we saw with optional union decoding including the index of the null type.

In the process of adding some test coverage around this I found another problematic case around null as a union member. That one is harder to fix, and not something that I'd expect us to do. For now I've marked the specs as pending for that case, and added an exception when we detect the situation.

Prime: @will89 