### PR TITLE
Allow mutable models via config option

### DIFF
--- a/lib/avromatic/model/builder.rb
+++ b/lib/avromatic/model/builder.rb
@@ -42,7 +42,7 @@ module Avromatic
       def inclusions
         [
           ActiveModel::Validations,
-          Virtus.value_object,
+          model_type_inclusion,
           Avromatic::Model::Configurable,
           Avromatic::Model::NestedModels,
           Avromatic::Model::Validation,
@@ -51,6 +51,10 @@ module Avromatic
           Avromatic::Model::RawSerialization,
           Avromatic::Model::MessagingSerialization
         ]
+      end
+
+      def model_type_inclusion
+        @config.immutable ? Virtus.value_object : Virtus.model
       end
 
       private

--- a/lib/avromatic/model/configuration.rb
+++ b/lib/avromatic/model/configuration.rb
@@ -4,7 +4,7 @@ module Avromatic
     # This class holds configuration for a model built from Avro schema(s).
     class Configuration
 
-      attr_reader :avro_schema, :key_avro_schema, :nested_models
+      attr_reader :avro_schema, :key_avro_schema, :nested_models, :immutable
       delegate :schema_store, to: Avromatic
 
       # Either schema(_name) or value_schema(_name), but not both, must be
@@ -23,6 +23,7 @@ module Avromatic
         raise ArgumentError.new('value_schema(_name) or schema(_name) must be specified') unless avro_schema
         @key_avro_schema = find_schema_by_option(:key_schema, **options)
         @nested_models = options[:nested_models]
+        @immutable = options.fetch(:immutable, true)
       end
 
       alias_method :value_avro_schema, :avro_schema

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -6,6 +6,10 @@ describe Avromatic::Model::Builder do
     described_class.model(schema_name: schema_name)
   end
 
+  let(:mutable_test_class) do
+    described_class.model(schema_name: schema_name, immutable: false)
+  end
+
   let(:attribute_names) do
     test_class.attribute_set.map(&:name).map(&:to_s)
   end
@@ -453,14 +457,24 @@ describe Avromatic::Model::Builder do
     let(:model1) { test_class.new(values) }
     let(:model2) { test_class.new(values) }
     let(:model3) { test_class.new(values.merge(s: 'bar')) }
+    let(:model4) { mutable_test_class.new(values) }
     let(:subclass) { Class.new(test_class) }
     let(:submodel) { subclass.new(values) }
+
 
     context "immutability" do
       it "prevents changes to models" do
         expect do
           model1.s = 'new value'
         end.to raise_error(NoMethodError, /private method `s=' called for/)
+      end
+    end
+
+    context "mutability" do
+      it "allows changes to mutable models" do
+        expect do
+          model4.s = 'new value'
+        end.not_to raise_error(NoMethodError, /private method `s=' called for/)
       end
     end
 


### PR DESCRIPTION
This PR adds a new configuration option to control the immutability of generated models.  Models are immutable by default.  Passing immutable: false to the builder will include Virtus.model instead of Virtus.value_object