### PR TITLE
Expose the key_attributes_for_avro method on models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## v0.24.0 (unreleased)
+- Expose the `#key_attributes_for_avro` method on models.
+
 ## v0.23.0
 - Add mutable option when defining a model.
 

--- a/lib/avromatic/model/raw_serialization.rb
+++ b/lib/avromatic/model/raw_serialization.rb
@@ -44,11 +44,11 @@ module Avromatic
           avro_hash(value_avro_field_names)
         end
 
-        private
-
         def key_attributes_for_avro
           avro_hash(key_avro_field_names)
         end
+
+        private
 
         def avro_hash(fields)
           attributes.slice(*fields).each_with_object(Hash.new) do |(key, value), result|

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.23.0'.freeze
+  VERSION = '0.24.0.rc0'.freeze
 end

--- a/spec/avromatic/io/datum_reader_spec.rb
+++ b/spec/avromatic/io/datum_reader_spec.rb
@@ -76,7 +76,6 @@ describe Avromatic::IO::DatumReader do
       let(:schema_name) { 'test.optional_union' }
 
       it "includes the member index in the decoded hash" do
-        puts instance.value_attributes_for_avro
         expect(attributes['message'][described_class::UNION_MEMBER_INDEX]).to eq(1)
       end
 

--- a/spec/avromatic/model/raw_serialization_spec.rb
+++ b/spec/avromatic/model/raw_serialization_spec.rb
@@ -12,6 +12,33 @@ describe Avromatic::Model::RawSerialization do
     Avromatic.messaging = nil
   end
 
+  describe "#value_attributes_for_avro" do
+    let(:test_class) do
+      Avromatic::Model.model(value_schema_name: 'test.encode_value')
+    end
+    let(:values) { { str1: 'a', str2: 'b' } }
+
+    it "returns a hash of attributes that will be encoded using avro" do
+      expected = values.stringify_keys
+      expect(instance.value_attributes_for_avro).to eq(expected)
+    end
+  end
+
+  describe "#key_attributes_for_avro" do
+    let(:test_class) do
+      Avromatic::Model.model(
+        value_schema_name: 'test.encode_value',
+        key_schema_name: 'test.encode_key'
+      )
+    end
+    let(:values) { super().merge!(str1: 'a', str2: 'b') }
+
+    it "returns a hash of the key attributes that will be encoded using avro" do
+      expected = { 'id' => values[:id] }
+      expect(instance.key_attributes_for_avro).to eq(expected)
+    end
+  end
+
   describe "#avro_raw_value" do
     let(:test_class) do
       Avromatic::Model.model(value_schema_name: 'test.encode_value')


### PR DESCRIPTION
There have been a couple of cases where it would have been useful for apps to have access to this private method. Its `#value_attributes_for_avro` sibling was already public. Also, increase test coverage since this is being exposed.

Prime: @jturkel 