### PR TITLE
Add Avromatic::IO::DatumWriter to optimize union encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # avromatic changelog
 
 ## v0.24.0 (unreleased)
+- Add `Avromatic::IO::DatumWriter` to optimize the encoding of Avro unions
+  from Avromatic models.
 - Expose the `#key_attributes_for_avro` method on models.
 
 ## v0.23.0

--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ end
   is included in the hash returned by the `DatumReader` but can be omitted by
   setting this option to `false`.
 
+#### Encoding
+* **use_custom_datum_writer**: `Avromatic` includes a modified subclass of
+  `Avro::IO::DatumWriter`. This subclass uses additional information about
+  the index of union members to optimize the encoding of Avro messages.
+  By default this information is included in the hash passed to the encoder
+  but can be omitted by setting this option to `false`.
+
+
 ### Models
 
 Models are defined based on an Avro schema for a record.

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -9,7 +9,8 @@ module Avromatic
   class << self
     attr_accessor :schema_registry, :registry_url, :schema_store, :logger,
                   :messaging, :type_registry, :nested_models,
-                  :use_custom_datum_reader, :use_schema_fingerprint_lookup
+                  :use_custom_datum_reader, :use_custom_datum_writer,
+                  :use_schema_fingerprint_lookup
 
     delegate :register_type, to: :type_registry
   end
@@ -18,6 +19,7 @@ module Avromatic
   self.logger = Logger.new($stdout)
   self.type_registry = Avromatic::Model::TypeRegistry.new
   self.use_custom_datum_reader = true
+  self.use_custom_datum_writer = true
   self.use_schema_fingerprint_lookup = true
 
   def self.configure

--- a/lib/avromatic/io.rb
+++ b/lib/avromatic/io.rb
@@ -1,0 +1,8 @@
+module Avromatic
+  module IO
+    UNION_MEMBER_INDEX = '__avromatic_member_index'.freeze
+  end
+end
+
+require 'avromatic/io/datum_reader'
+require 'avromatic/io/datum_writer'

--- a/lib/avromatic/io/datum_reader.rb
+++ b/lib/avromatic/io/datum_reader.rb
@@ -6,7 +6,7 @@ module Avromatic
     # branch 'salsify-master' with the tag 'v1.9.0.3'
     class DatumReader < Avro::IO::DatumReader
 
-      UNION_MEMBER_INDEX = '__avromatic_member_index'.freeze
+      UNION_MEMBER_INDEX = Avromatic::IO::UNION_MEMBER_INDEX
 
       def read_data(writers_schema, readers_schema, decoder, initial_record = {})
         # schema matching

--- a/lib/avromatic/io/datum_writer.rb
+++ b/lib/avromatic/io/datum_writer.rb
@@ -1,0 +1,25 @@
+module Avromatic
+  module IO
+    # Subclass DatumWriter to use additional information about union member
+    # index.
+    class DatumWriter < Avro::IO::DatumWriter
+      def write_union(writers_schema, datum, encoder)
+        optional = writers_schema.schemas.first.type_sym == :null
+        if datum.is_a?(Hash) && datum.key?(Avromatic::IO::UNION_MEMBER_INDEX)
+          index_of_schema = datum[Avromatic::IO::UNION_MEMBER_INDEX]
+          # Avromatic does not treat the null of an optional field as part of the union
+          index_of_schema += 1 if optional
+        else
+          index_of_schema = writers_schema.schemas.find_index do |schema|
+            Avro::Schema.validate(schema, datum)
+          end
+        end
+        unless index_of_schema
+          raise Avro::IO::AvroTypeError.new(writers_schema, datum)
+        end
+        encoder.write_long(index_of_schema)
+        write_data(writers_schema.schemas[index_of_schema], datum, encoder)
+      end
+    end
+  end
+end

--- a/lib/avromatic/messaging.rb
+++ b/lib/avromatic/messaging.rb
@@ -39,9 +39,6 @@ module Avromatic
       schema_id = @registry.register(subject || schema.fullname, schema)
 
       stream = StringIO.new
-
-      # The following line differs from the parent class to use a custom DatumWriter
-      writer = Avromatic::IO::DatumWriter.new(schema)
       encoder = Avro::IO::BinaryEncoder.new(stream)
 
       # Always start with the magic byte.
@@ -49,6 +46,9 @@ module Avromatic
 
       # The schema id is encoded as a 4-byte big-endian integer.
       encoder.write([schema_id].pack('N'))
+
+      # The following line differs from the parent class to use a custom DatumWriter
+      writer = Avromatic::IO::DatumWriter.new(schema)
 
       # The actual message comes last.
       writer.write(message, encoder)

--- a/lib/avromatic/messaging.rb
+++ b/lib/avromatic/messaging.rb
@@ -1,8 +1,8 @@
 require 'avro_turf/messaging'
-require 'avromatic/io/datum_reader'
+require 'avromatic/io'
 
 module Avromatic
-  # Subclass AvroTurf::Messaging to use a custom DatumReader for decode.
+  # Subclass AvroTurf::Messaging to use a custom DatumReader and DatumWriter
   class Messaging < AvroTurf::Messaging
     attr_reader :registry
 
@@ -29,6 +29,31 @@ module Avromatic
       # The following line differs from the parent class to use a custom DatumReader
       reader = Avromatic::IO::DatumReader.new(writers_schema, readers_schema)
       reader.read(decoder)
+    end
+
+    def encode(message, schema_name: nil, namespace: @namespace, subject: nil)
+      schema = @schema_store.find(schema_name, namespace)
+
+      # Schemas are registered under the full name of the top level Avro record
+      # type, or `subject` if it's provided.
+      schema_id = @registry.register(subject || schema.fullname, schema)
+
+      stream = StringIO.new
+
+      # The following line differs from the parent class to use a custom DatumWriter
+      writer = Avromatic::IO::DatumWriter.new(schema)
+      encoder = Avro::IO::BinaryEncoder.new(stream)
+
+      # Always start with the magic byte.
+      encoder.write(MAGIC_BYTE)
+
+      # The schema id is encoded as a 4-byte big-endian integer.
+      encoder.write([schema_id].pack('N'))
+
+      # The actual message comes last.
+      writer.write(message, encoder)
+
+      stream.string
     end
   end
 end

--- a/lib/avromatic/model/attribute/union.rb
+++ b/lib/avromatic/model/attribute/union.rb
@@ -1,5 +1,5 @@
 require 'avromatic/model/attribute_type/union'
-require 'avromatic/io/datum_reader'
+require 'avromatic/io'
 
 module Avromatic
   module Model

--- a/spec/avromatic/io/datum_writer_spec.rb
+++ b/spec/avromatic/io/datum_writer_spec.rb
@@ -1,0 +1,53 @@
+describe Avromatic::IO::DatumWriter do
+  let(:encoder) { instance_double(Avro::IO::BinaryEncoder) }
+  let(:schema_name) { 'test.real_union' }
+  let(:test_class) do
+    Avromatic::Model.model(schema_name: schema_name)
+  end
+  let(:values) do
+    {
+      headers: 'has bar',
+      message: { bar_message: 'bar' }
+    }
+  end
+  let(:instance) { test_class.new(values) }
+  let(:use_custom_datum_writer) { true }
+  let(:datum_writer) { described_class.new(test_class.value_avro_schema) }
+  let(:union_schema) do
+    test_class.value_avro_schema.fields.find { |f| f.name == 'message' }.type
+  end
+  let(:datum) { instance.value_attributes_for_avro['message'] }
+
+  before do
+    allow(Avromatic).to receive(:use_custom_datum_writer).and_return(use_custom_datum_writer)
+    allow(Avro::Schema).to receive(:validate).and_call_original
+    allow(encoder).to receive(:write_long)
+    allow(datum_writer).to receive(:write_data)
+  end
+
+  describe "#write_union" do
+    before { datum_writer.write_union(union_schema, datum, encoder) }
+
+    context "when the datum includes union member index" do
+      it "does not call Avro::Schema.validate" do
+        expect(Avro::Schema).not_to have_received(:validate)
+      end
+
+      it "calls write_data to encode the union" do
+        expect(datum_writer).to have_received(:write_data).with(union_schema.schemas[1], datum, encoder)
+      end
+    end
+
+    context "when the datum does not include union member index" do
+      let(:use_custom_datum_writer) { false }
+
+      it "calls validate to find the matching schema" do
+        expect(Avro::Schema).to have_received(:validate).twice
+      end
+
+      it "calls write_data to encode the union" do
+        expect(datum_writer).to have_received(:write_data).with(union_schema.schemas[1], datum, encoder)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ end
 
 require 'avro/builder'
 require 'avromatic'
+require 'active_support/core_ext/hash/keys'
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 


### PR DESCRIPTION
This change adds the index of the union member type to records within unions. When this information is present the new `DatumWriter` class can encode the union datum directly without having to check the other member types.

Prime: @jturkel 