### PR TITLE
Cache avro encoding for immutable models [IN-48]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## v0.28.0
+- Add support for caching avro encodings for immutable models
+
 ## v0.27.0
 - Patches avromatic model classes to cache `Virtus::ValueObject::AllowedWriterMethods#allowed_writer_methods`
 - Support Rails 5.1

--- a/README.md
+++ b/README.md
@@ -99,10 +99,11 @@ end
 
 #### Encoding
 * **use_custom_datum_writer**: `Avromatic` includes a modified subclass of
-  `Avro::IO::DatumWriter`. This subclass uses additional information about
-  the index of union members to optimize the encoding of Avro messages.
-  By default this information is included in the hash passed to the encoder
-  but can be omitted by setting this option to `false`.
+  `Avro::IO::DatumWriter`. This subclass supports caching avro encodings for 
+  immutable models and uses additional information about the index of union 
+  members to optimize the encoding of Avro messages. By default this 
+  information is included in the hash passed to the encoder but can be omitted
+  by setting this option to `false`.
 
 
 ### Models

--- a/lib/avromatic/io.rb
+++ b/lib/avromatic/io.rb
@@ -1,6 +1,7 @@
 module Avromatic
   module IO
     UNION_MEMBER_INDEX = '__avromatic_member_index'.freeze
+    ENCODING_PROVIDER = '__avromatic_encoding_provider'.freeze
   end
 end
 

--- a/lib/avromatic/io/datum_writer.rb
+++ b/lib/avromatic/io/datum_writer.rb
@@ -20,6 +20,14 @@ module Avromatic
         encoder.write_long(index_of_schema)
         write_data(writers_schema.schemas[index_of_schema], datum, encoder)
       end
+
+      def write_record(writers_schema, datum, encoder)
+        if datum.is_a?(Hash) && datum.key?(Avromatic::IO::ENCODING_PROVIDER)
+          encoder.write(datum[Avromatic::IO::ENCODING_PROVIDER].avro_raw_value)
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/lib/avromatic/model/raw_serialization.rb
+++ b/lib/avromatic/model/raw_serialization.rb
@@ -29,6 +29,9 @@ module Avromatic
             if value.is_a?(Avromatic::Model::Attributes)
               hash = value.value_attributes_for_avro
               if Avromatic.use_custom_datum_writer
+                unless value.class.config.mutable
+                  hash = { Avromatic::IO::ENCODING_PROVIDER => value }
+                end
                 member_index = member_types.index(value.class) if member_types.any?
                 hash[Avromatic::IO::UNION_MEMBER_INDEX] = member_index if member_index
               end
@@ -67,7 +70,11 @@ module Avromatic
         end
 
         def avro_raw_value
-          avro_raw_encode(value_attributes_for_avro, :value)
+          if self.class.config.mutable
+            avro_raw_encode(value_attributes_for_avro, :value)
+          else
+            @avro_raw_value ||= avro_raw_encode(value_attributes_for_avro, :value)
+          end
         end
 
         def avro_raw_key

--- a/lib/avromatic/model/raw_serialization.rb
+++ b/lib/avromatic/model/raw_serialization.rb
@@ -30,6 +30,8 @@ module Avromatic
               hash = value.value_attributes_for_avro
               if Avromatic.use_custom_datum_writer
                 unless value.class.config.mutable
+                  # n.b. Ideally we'd just return value here instead of wrapping it in a
+                  # hash but then we'd have no place to stash the union member index...
                   hash = { Avromatic::IO::ENCODING_PROVIDER => value }
                 end
                 member_index = member_types.index(value.class) if member_types.any?

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.27.0'.freeze
+  VERSION = '0.28.0'.freeze
 end

--- a/spec/avro/dsl/test/wrapper.rb
+++ b/spec/avro/dsl/test/wrapper.rb
@@ -1,0 +1,15 @@
+namespace 'test'
+
+record :wrapped1 do
+  required :i, :int
+end
+
+record :wrapped2 do
+  required :i, :int
+end
+
+record :wrapper do
+  required :sub1, :wrapped1
+  required :sub2, :wrapped1
+  required :sub3, :wrapped2
+end

--- a/spec/avro/schema/test/wrapper.avsc
+++ b/spec/avro/schema/test/wrapper.avsc
@@ -1,0 +1,39 @@
+{
+  "type": "record",
+  "name": "wrapper",
+  "namespace": "test",
+  "fields": [
+    {
+      "name": "sub1",
+      "type": {
+        "type": "record",
+        "name": "wrapped1",
+        "namespace": "test",
+        "fields": [
+          {
+            "name": "i",
+            "type": "int"
+          }
+        ]
+      }
+    },
+    {
+      "name": "sub2",
+      "type": "test.wrapped1"
+    },
+    {
+      "name": "sub3",
+      "type": {
+        "type": "record",
+        "name": "wrapped2",
+        "namespace": "test",
+        "fields": [
+          {
+            "name": "i",
+            "type": "int"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/spec/avromatic/io/datum_writer_spec.rb
+++ b/spec/avromatic/io/datum_writer_spec.rb
@@ -50,4 +50,30 @@ describe Avromatic::IO::DatumWriter do
       end
     end
   end
+
+  describe "#write_record" do
+    let(:message) { datum }
+
+    before do
+      allow(message).to receive(:avro_raw_value)
+      allow(encoder).to receive(:write)
+      datum_writer.write_record(union_schema.schemas[1], datum, encoder)
+    end
+
+    context "when the datum includes an encoding provider" do
+      let(:message) { datum[Avromatic::IO::ENCODING_PROVIDER] }
+
+      it "delegates encoding to the model" do
+        expect(message).to have_received(:avro_raw_value)
+      end
+    end
+
+    context "when the datum doesn't include an encoding provider" do
+      let(:use_custom_datum_writer) { false }
+
+      it "doesn't delegate encoding to the model" do
+        expect(message).not_to have_received(:avro_raw_value)
+      end
+    end
+  end
 end

--- a/spec/avromatic/io/datum_writer_spec.rb
+++ b/spec/avromatic/io/datum_writer_spec.rb
@@ -53,9 +53,10 @@ describe Avromatic::IO::DatumWriter do
 
   describe "#write_record" do
     let(:message) { datum }
+    let(:pre_encoded) { 'foo' }
 
     before do
-      allow(message).to receive(:avro_raw_value)
+      allow(message).to receive(:avro_raw_value).and_return(pre_encoded)
       allow(encoder).to receive(:write)
       datum_writer.write_record(union_schema.schemas[1], datum, encoder)
     end
@@ -64,7 +65,7 @@ describe Avromatic::IO::DatumWriter do
       let(:message) { datum[Avromatic::IO::ENCODING_PROVIDER] }
 
       it "delegates encoding to the model" do
-        expect(message).to have_received(:avro_raw_value)
+        expect(encoder).to have_received(:write).with(pre_encoded)
       end
     end
 
@@ -72,7 +73,9 @@ describe Avromatic::IO::DatumWriter do
       let(:use_custom_datum_writer) { false }
 
       it "doesn't delegate encoding to the model" do
-        expect(message).not_to have_received(:avro_raw_value)
+        union_schema.schemas[1].fields.each do |field|
+          expect(datum_writer).to have_received(:write_data).with(field.type, datum[field.name], encoder)
+        end
       end
     end
   end

--- a/spec/avromatic/model/raw_serialization_spec.rb
+++ b/spec/avromatic/model/raw_serialization_spec.rb
@@ -8,6 +8,7 @@ describe Avromatic::Model::RawSerialization do
   let(:avro_raw_key) { instance.avro_raw_key }
   let(:use_custom_datum_writer) { true }
   let(:member_index) { Avromatic::IO::UNION_MEMBER_INDEX }
+  let(:encoding_provider) { Avromatic::IO::ENCODING_PROVIDER }
 
   before do
     # Ensure that there is no dependency on messaging
@@ -26,12 +27,80 @@ describe Avromatic::Model::RawSerialization do
       expect(instance.value_attributes_for_avro).to eq(expected)
     end
 
+    context "with a nested record" do
+      let!(:test_class) do
+        Avromatic::Model.model(value_schema_name: 'test.nested_record')
+      end
+      let(:sub) { Avromatic.nested_models['test.__nested_record_sub_record'].new(str: 'b', i: 1) }
+      let(:values) { { str: 'a', sub: sub } }
+
+      it "reuses cacheable attributes" do
+        expected = values.deep_stringify_keys
+        expected['sub'] = { encoding_provider => sub }
+        actual = instance.value_attributes_for_avro
+        expect(actual).to eq(expected)
+        expect(actual['sub'][encoding_provider].object_id).to eq(sub.object_id)
+      end
+    end
+
+    context "with repeated references to a named type" do
+      let!(:test_class) do
+        Avromatic::Model.model(value_schema_name: 'test.wrapper')
+      end
+      let(:wrapped1) { Avromatic.nested_models['test.wrapped1'].new(i: 42) }
+      let(:wrapped2) { Avromatic.nested_models['test.wrapped2'].new(i: 78) }
+      let(:values) { { sub1: wrapped1, sub2: wrapped1, sub3: wrapped2 } }
+
+      it "reuses cacheable attributes" do
+        expected = values.deep_stringify_keys.map { |k, v| [k, { encoding_provider => v }] }.to_h
+        actual = instance.value_attributes_for_avro
+        expect(actual).to eq(expected)
+        expect(actual['sub1'][encoding_provider].object_id).to eq(wrapped1.object_id)
+        expect(actual['sub2'][encoding_provider].object_id).to eq(wrapped1.object_id)
+        expect(actual['sub3'][encoding_provider].object_id).to eq(wrapped2.object_id)
+      end
+    end
+
+    context "with reference to a mutable attribute" do
+      let!(:test_class) do
+        Avromatic::Model.model(value_schema_name: 'test.wrapper')
+      end
+      let(:wrapped1_class) { Avromatic.nested_models['test.wrapped1'] }
+      let(:wrapped2_class) { Avromatic.nested_models['test.wrapped2'] }
+      let(:wrapped1) { wrapped1_class.new(i: 42) }
+      let(:wrapped2) { wrapped1_class.new(i: 78) }
+      let(:wrapped3) { wrapped2_class.new(i: 96) }
+      let(:values) { { sub1: wrapped1, sub2: wrapped2, sub3: wrapped3 } }
+
+      before do
+        allow(wrapped1_class.config).to receive(:mutable).and_return(true)
+      end
+
+      it "doesn't cache mutable attributes" do
+        expected = values.deep_stringify_keys
+        expected['sub1'] = wrapped1.value_attributes_for_avro
+        expected['sub2'] = wrapped2.value_attributes_for_avro
+        expected['sub3'] = { encoding_provider => wrapped3 }
+        actual = instance.value_attributes_for_avro
+        expect(actual).to eq(expected)
+        expect(actual['sub1'][encoding_provider].object_id).not_to eq(wrapped1.object_id)
+        expect(actual['sub2'][encoding_provider].object_id).not_to eq(wrapped2.object_id)
+        expect(actual['sub3'][encoding_provider].object_id).to eq(wrapped3.object_id)
+      end
+    end
+
     context "caching" do
       context "immutable model" do
         it "caches a hash of attributes that will be encoded using avro" do
           value_attributes1 = instance.value_attributes_for_avro
           value_attributes2 = instance.value_attributes_for_avro
           expect(value_attributes1.object_id).to eq(value_attributes2.object_id)
+        end
+
+        it "caches the avro encoding" do
+          encoded1 = instance.avro_raw_value
+          encoded2 = instance.avro_raw_value
+          expect(encoded1.object_id).to eq(encoded2.object_id)
         end
       end
 
@@ -40,33 +109,43 @@ describe Avromatic::Model::RawSerialization do
           Avromatic::Model.model(value_schema_name: 'test.encode_value', mutable: true)
         end
 
-        it "caches a hash of attributes that will be encoded using avro" do
+        it "doesn't cache hash of attributes that will be encoded using avro" do
           value_attributes1 = instance.value_attributes_for_avro
           value_attributes2 = instance.value_attributes_for_avro
           expect(value_attributes1.object_id).not_to eq(value_attributes2.object_id)
+        end
+
+        it "doesn't cache the avro encoding" do
+          encoded1 = instance.avro_raw_value
+          encoded2 = instance.avro_raw_value
+          expect(encoded1.object_id).not_to eq(encoded2.object_id)
         end
       end
     end
 
     context "a record with a union" do
-      let(:test_class) do
+      let!(:test_class) do
         Avromatic::Model.model(value_schema_name: 'test.real_union')
       end
+      let(:bar_message) { Avromatic.nested_models['test.bar'].new(bar_message: "I'm a bar") }
       let(:values) do
         {
           header: 'has bar',
-          message: { bar_message: "I'm a bar" }
+          message: bar_message
         }
       end
 
       it "includes union member index in the hash of attributes" do
         expected = values.deep_stringify_keys
-        expected['message'][member_index] = 1
-        expect(instance.value_attributes_for_avro).to eq(expected)
+        expected['message'] = { encoding_provider => bar_message, member_index => 1 }
+        actual = instance.value_attributes_for_avro
+        expect(actual).to eq(expected)
+        expect(actual['message'][encoding_provider].object_id).to eq(bar_message.object_id)
       end
 
       context "when use_custom_datum_writer is false" do
         let(:use_custom_datum_writer) { false }
+        let(:bar_message) { { bar_message: "I'm a bar" } }
 
         it "does not include union member index in the hash of attributes" do
           expected = values.deep_stringify_keys

--- a/spec/avromatic/model/raw_serialization_spec.rb
+++ b/spec/avromatic/model/raw_serialization_spec.rb
@@ -47,7 +47,7 @@ describe Avromatic::Model::RawSerialization do
       let(:values) { { sub1: wrapped1, sub2: wrapped1, sub3: wrapped2 } }
 
       it "reuses cacheable attributes" do
-        expected = values.deep_stringify_keys.map { |k, v| [k, { encoding_provider => v }] }.to_h
+        expected = values.deep_stringify_keys.each_with_object({}) { |(k, v), hash| hash[k] = { encoding_provider => v } }
         actual = instance.value_attributes_for_avro
         expect(actual).to eq(expected)
         expect(actual['sub1'][encoding_provider]).to equal(wrapped1)


### PR DESCRIPTION
This change introduces caching of avro encodings for immutable models with an eye toward speeding up percolate match handling when products match multiple subscriptions.

RawSerialization::recursive_serialize was changed s.t. for immutable models, instead of producing a hash of serialized values, it provides a signal to the DatumWriter to delegate back to the model for the avro encoding. The DatumWriter was correspondingly updated to respond to this hint by calling the model's avro_raw_value which is now memoized.

Before
![image](https://user-images.githubusercontent.com/9824920/29428702-1ea9a768-835c-11e7-9e77-5fd88215b5ae.png)

After
![image](https://user-images.githubusercontent.com/9824920/29428672-0e2a4b72-835c-11e7-9ef5-97d326ab0000.png)

prime: @tjwp