### PR TITLE
Add #avro_value_datum and #avro_key_datum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # avromatic changelog
 
+## v0.29.0
+- Add new public methods `#avro_key_datum` and `#avro_value_datum` on an
+  Avromatic model instance that return the attributes of the model suitable for
+  Avro encoding without any customizations.
+
 ## v0.28.1
 - Fix a bug that raised an error when encoding a cached model containing optional
   field(s). With this change, immutable model caching now enabled only when 

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.28.1'.freeze
+  VERSION = '0.29.0'.freeze
 end


### PR DESCRIPTION
I added public methods to Avromatic model instances to return the equivalent of `#value_attributes_for_avro` but excluding the custom values for union member index and encoding provider. 

I went with the term `datum` as it appears throughout the Avro gem source for the data to be encoded using Avro.

The tests are based on the examples for `#value_attributes_for_avro` but demonstrate the difference of what the new methods return.

The implementation is via the passing of a `:strict` flag indicating that result should strictly conform to Avro specification.

Prime: @jkapell

Fixes #77 