### PR TITLE
Add build_messaging! to avromatic/rspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## v0.29.1
+- Add `Avromatic.build_messaging!` to `avromatic/rspec`.
+
 ## v0.29.0
 - Add new public methods `#avro_key_datum` and `#avro_value_datum` on an
   Avromatic model instance that return the attributes of the model suitable for

--- a/README.md
+++ b/README.md
@@ -409,6 +409,15 @@ To use this gem, reference it in your Gemfile instead of `avro`:
 gem 'avro-patches'
 ````
 
+### RSpec Support
+
+This gem also includes an `"avromatic/rspec"` file that can be required to support
+using Avromatic with a fake schema registry during tests.
+
+Requiring this file configures a RSpec before hook that directs any schema
+registry requests to a fake, in-memory schema registry and rebuilds the
+`Avromatic::Messaging` object for each example.
+
 ### Unsupported/Future
 
 The following types/features are not supported for generated models:

--- a/lib/avromatic/rspec.rb
+++ b/lib/avromatic/rspec.rb
@@ -5,5 +5,6 @@ RSpec.configure do |config|
   config.before(:each) do
     WebMock.stub_request(:any, /^#{Avromatic.registry_url}/).to_rack(AvroSchemaRegistry::FakeServer)
     AvroSchemaRegistry::FakeServer.clear
+    Avromatic.build_messaging!
   end
 end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.29.0'.freeze
+  VERSION = '0.29.1'.freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,6 @@ RSpec.configure do |config|
     Avromatic.registry_url = 'http://registry.example.com'
     Avromatic.use_schema_fingerprint_lookup = true
     Avromatic.schema_store = AvroTurf::SchemaStore.new(path: 'spec/avro/schema')
-    Avromatic.build_messaging!
     Avromatic.type_registry.clear
     Avromatic.nested_models = Avromatic::ModelRegistry.new
   end


### PR DESCRIPTION
The RSpec support in `avromatic/rspec` does not actually work unless it is paired with calling `Avromatic.build_messaging!` also before each example.

It makes sense to also include this in the support file. 

Also, added a section to the README describing the RSpec support.

Prime: @jturkel 
CC: @zoso10