### PR TITLE
Test against Ruby 2.5 and bump patch versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-  - 2.4.1
-  - 2.3.4
-  - 2.2.7
+  - 2.5.0
+  - 2.4.3
+  - 2.3.5
+  - 2.2.8
 before_script:
   - bundle exec appraisal install --jobs=3
 script:

--- a/Appraisals
+++ b/Appraisals
@@ -12,14 +12,14 @@ end
 
 appraise 'rails5_0' do
   gem 'avro', '1.8.2'
-  gem 'activesupport', '~> 5.0.5'
-  gem 'activemodel', '~> 5.0.5'
+  gem 'activesupport', '~> 5.0.6'
+  gem 'activemodel', '~> 5.0.6'
 end
 
 appraise 'rails5_1' do
   gem 'avro', '1.8.2'
-  gem 'activesupport', '~> 5.1.2'
-  gem 'activemodel', '~> 5.1.2'
+  gem 'activesupport', '~> 5.1.4'
+  gem 'activemodel', '~> 5.1.4'
 end
 
 appraise 'avro-patches-4_1' do
@@ -30,12 +30,12 @@ end
 
 appraise 'avro-patches-5_0' do
   gem 'avro-patches'
-  gem 'activesupport', '~> 5.0.5'
-  gem 'activemodel', '~> 5.0.5'
+  gem 'activesupport', '~> 5.0.6'
+  gem 'activemodel', '~> 5.0.6'
 end
 
 appraise 'avro-patches-5_1' do
   gem 'avro-patches'
-  gem 'activesupport', '~> 5.1.2'
-  gem 'activemodel', '~> 5.1.2'
+  gem 'activesupport', '~> 5.1.4'
+  gem 'activemodel', '~> 5.1.4'
 end

--- a/gemfiles/avro_patches_5_0.gemfile
+++ b/gemfiles/avro_patches_5_0.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "avro-patches"
-gem "activesupport", "~> 5.0.5"
-gem "activemodel", "~> 5.0.5"
+gem "activesupport", "~> 5.0.6"
+gem "activemodel", "~> 5.0.6"
 
 gemspec path: "../"

--- a/gemfiles/avro_patches_5_1.gemfile
+++ b/gemfiles/avro_patches_5_1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "avro-patches"
-gem "activesupport", "~> 5.1.2"
-gem "activemodel", "~> 5.1.2"
+gem "activesupport", "~> 5.1.4"
+gem "activemodel", "~> 5.1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails5_0.gemfile
+++ b/gemfiles/rails5_0.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "avro", "1.8.2"
-gem "activesupport", "~> 5.0.5"
-gem "activemodel", "~> 5.0.5"
+gem "activesupport", "~> 5.0.6"
+gem "activemodel", "~> 5.0.6"
 
 gemspec path: "../"

--- a/gemfiles/rails5_1.gemfile
+++ b/gemfiles/rails5_1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "avro", "1.8.2"
-gem "activesupport", "~> 5.1.2"
-gem "activemodel", "~> 5.1.2"
+gem "activesupport", "~> 5.1.4"
+gem "activemodel", "~> 5.1.4"
 
 gemspec path: "../"


### PR DESCRIPTION
This adds testing against Ruby 2.5.0 to the Travis configuration (no issues found), and bumps the patch versions for Ruby and Rails.

Prime: @jturkel 