### PR TITLE
Add MessageDecoder method to return model only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # avromatic changelog
 
+## v0.30.0
+- Add `Avromatic::Model::MessageDecoder#model` method to return the Avromatic
+  model class for a message.
+
 ## v0.29.1
 - Add `Avromatic.build_messaging!` to `avromatic/rspec`.
 

--- a/lib/avromatic/model/message_decoder.rb
+++ b/lib/avromatic/model/message_decoder.rb
@@ -57,6 +57,11 @@ module Avromatic
         model.avro_message_attributes(message_key, message_value)
       end
 
+      # @return [Avromatic model class]
+      def model(*args)
+        extract_decode_args(*args).first
+      end
+
       private
 
       attr_reader :schema_names_by_id, :model_map, :schema_registry

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.29.1'.freeze
+  VERSION = '0.30.0'.freeze
 end

--- a/spec/avromatic/model/message_decoder_spec.rb
+++ b/spec/avromatic/model/message_decoder_spec.rb
@@ -65,6 +65,23 @@ describe Avromatic::Model::MessageDecoder do
     end
   end
 
+  describe "#model" do
+    let(:models) { [model1, model2] }
+    let(:model1_instance) { model1.new(str1: 'A', str2: 'B', id: 99) }
+    let(:model1_value) do
+      model1_instance.avro_message_value
+    end
+    let(:model1_key) do
+      model1_instance.avro_message_key
+    end
+
+    it "returns the associated model for a message" do
+      expect(instance.model(model1_key, model1_value)).to equal(model1)
+    end
+
+    it_behaves_like "decoding failure cases", :model
+  end
+
   describe "#decode" do
     let(:models) { [model1, model2] }
     let(:model1_instance) { model1.new(str1: 'A', str2: 'B', id: 99) }


### PR DESCRIPTION
We have a use case where we want to dispatch only on the model associated with a message without performing a full decode.

This change exposes a method to return just the model based on a message key and value.

Prime: @jturkel 
  