### PR TITLE
Improve record assignment from a hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # avromatic changelog
 
+## v0.32.0 (unreleased)
+- Improve partial assignment using a hash for records outside of unions.
+- Prevent invalid types from being assigned to primitives in unions.
+- Add validation that primitive attributes have the expected type.
+
 ## v0.31.0
-= Add support for Rails 5.2.
+- Add support for Rails 5.2.
 
 ## v0.30.0
 - Add `Avromatic::Model::MessageDecoder#model` method to return the Avromatic

--- a/lib/avromatic/model/allowed_type_validator.rb
+++ b/lib/avromatic/model/allowed_type_validator.rb
@@ -1,0 +1,7 @@
+class AllowedTypeValidator < ActiveModel::EachValidator
+  def validate_each(record, name, value)
+    if options[:in].find { |klass| value.is_a?(klass) }.nil?
+      record.errors[name] << "does not have the expected type #{options[:in]}"
+    end
+  end
+end

--- a/lib/avromatic/model/attribute/record.rb
+++ b/lib/avromatic/model/attribute/record.rb
@@ -12,10 +12,9 @@ module Avromatic
         primitive Avromatic::Model::Attributes
 
         def coerce(value)
-          return value if value.nil? || value_coerced?(value)
+          return value if value.nil? || value.is_a?(primitive)
 
-          coerced = primitive.new(value)
-          coerced if coerced.valid?
+          primitive.new(value)
         end
 
         def value_coerced?(value)

--- a/lib/avromatic/model/attribute/union.rb
+++ b/lib/avromatic/model/attribute/union.rb
@@ -47,7 +47,12 @@ module Avromatic
 
         def safe_coerce(member_attribute, input)
           coerced = member_attribute.coerce(input)
-          coerced unless coerced.is_a?(Avromatic::Model::Attributes) && coerced.invalid?
+
+          if coerced.is_a?(Avromatic::Model::Attributes)
+            coerced if coerced.valid?
+          elsif member_attribute.coerced?(coerced)
+            coerced
+          end
         rescue
           nil
         end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.31.0'.freeze
+  VERSION = '0.32.0.rc0'.freeze
 end

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -266,6 +266,70 @@ describe Avromatic::Model::Builder do
   context "coercion" do
     # This is important for the eventual encoding of a model to Avro
 
+    context "primitives" do
+      let(:schema_name) { 'test.primitive_types' }
+
+      context "string" do
+        it "coerces an integer to a string" do
+          expect(test_class.new(s: 100).s).to eq("100")
+        end
+
+        it "does not coerce a Hash to a string" do
+          instance = test_class.new(s: { x: 1 })
+          expect(instance.s).to eq({ x: 1 })
+        end
+      end
+
+      context "integer" do
+        it "does not coerce a Hash to an integer" do
+          instance = test_class.new(i: { x: 2 })
+          expect(instance.i).to eq(x: 2)
+        end
+      end
+
+      context "boolean" do
+        it "does not coerce a Hash to a boolean" do
+          instance = test_class.new(tf: { x: 3 })
+          expect(instance.tf).to eq(x: 3)
+        end
+      end
+
+      context "bytes" do
+        it "does not coerce a Hash to bytes" do
+          instance = test_class.new(b: { x: 4 })
+          expect(instance.b).to eq(x: 4)
+        end
+      end
+
+      context "long" do
+        it "does not coerce a Hash to a long" do
+          instance = test_class.new(l: { x: 5 })
+          expect(instance.l).to eq(x: 5)
+        end
+      end
+
+      context "float" do
+        it "does not coerce a Hash to a float" do
+          instance = test_class.new(f: { x: 6 })
+          expect(instance.f).to eq(x: 6)
+        end
+      end
+
+      context "double" do
+        it "does not coerce a Hash to a double" do
+          instance = test_class.new(d: { x: 7 })
+          expect(instance.d).to eq(x: 7)
+        end
+      end
+
+      context "null" do
+        it "does not coerce a Hash to nil" do
+          instance = test_class.new(n: { x: 8 })
+          expect(instance.n).to eq(x: 8)
+        end
+      end
+    end
+
     context "enum" do
       let(:schema_name) { 'test.named_fields' }
 

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -271,12 +271,12 @@ describe Avromatic::Model::Builder do
 
       context "string" do
         it "coerces an integer to a string" do
-          expect(test_class.new(s: 100).s).to eq("100")
+          expect(test_class.new(s: 100).s).to eq('100')
         end
 
         it "does not coerce a Hash to a string" do
           instance = test_class.new(s: { x: 1 })
-          expect(instance.s).to eq({ x: 1 })
+          expect(instance.s).to eq(x: 1)
         end
       end
 

--- a/spec/avromatic/model/builder_validation_spec.rb
+++ b/spec/avromatic/model/builder_validation_spec.rb
@@ -7,6 +7,74 @@ describe Avromatic::Model::Builder, 'validation' do
     test_class.attribute_set.map(&:name).map(&:to_s)
   end
 
+  context "primitives" do
+    let(:schema_name) { 'test.primitive_types' }
+
+    context "string" do
+      it "validates that a string has the correct type" do
+        instance = test_class.new(s: { x: 1 })
+        expect(instance).to be_invalid
+        expect(instance.errors[:s]).to include('does not have the expected type [String]')
+      end
+    end
+
+    context "integer" do
+      it "validates that an integer has the correct type" do
+        instance = test_class.new(i: { x: 2 })
+        expect(instance).to be_invalid
+        expect(instance.errors[:i]).to include('does not have the expected type [Integer]')
+      end
+    end
+
+    context "boolean" do
+      it "validates that a boolean has the correct type" do
+        instance = test_class.new(tf: { x: 3 })
+        expect(instance).to be_invalid
+        expect(instance.errors[:tf]).to include('does not have the expected type [TrueClass, FalseClass]')
+      end
+    end
+
+    context "bytes" do
+      it "validates that bytes have the correct type" do
+        instance = test_class.new(b: { x: 4 })
+        expect(instance).to be_invalid
+        expect(instance.errors[:b]).to include('does not have the expected type [String]')
+      end
+    end
+
+    context "long" do
+      it "validates that a long has the correct type" do
+        instance = test_class.new(l: { x: 5 })
+        expect(instance).to be_invalid
+        expect(instance.errors[:l]).to include('does not have the expected type [Integer]')
+      end
+    end
+
+    context "float" do
+      it "validates that a float has the correct type" do
+        instance = test_class.new(f: { x: 6 })
+        expect(instance).to be_invalid
+        expect(instance.errors[:f]).to include('does not have the expected type [Float]')
+      end
+    end
+
+    context "double" do
+      it "validates that a double has the correct type" do
+        instance = test_class.new(d: { x: 7 })
+        expect(instance).to be_invalid
+        expect(instance.errors[:d]).to include('does not have the expected type [Float]')
+      end
+    end
+
+    context "null" do
+      it "validates that a null field has the correct type" do
+        instance = test_class.new(n: { x: 8 })
+        expect(instance).to be_invalid
+        expect(instance.errors[:n]).to include('does not have the expected type [NilClass]')
+      end
+    end
+  end
+
   context "fixed" do
     let(:schema_name) { 'test.named_fields' }
 
@@ -24,6 +92,73 @@ describe Avromatic::Model::Builder, 'validation' do
       instance = test_class.new(e: :C)
       expect(instance).to be_invalid
       expect(instance.errors[:e]).to include('is not included in the list')
+    end
+  end
+
+  context "logical types" do
+    let(:schema_name) { 'test.logical_types' }
+
+    context "timestamp-millis" do
+      it "accepts a Time" do
+        instance = test_class.new(ts_msec: Time.now)
+        instance.validate
+        expect(instance.errors[:ts_msec]).to be_empty
+      end
+
+      it "accepts an ActiveSupport::TimeWithZone" do
+        Time.zone = 'GMT'
+        instance = test_class.new(ts_msec: Time.zone.now)
+        instance.validate
+        expect(instance.errors[:ts_msec]).to be_empty
+      end
+
+      it "validates that a timestamp-millis is a Time" do
+        instance = test_class.new(ts_msec: Date.today)
+        expect(instance).to be_invalid
+        expect(instance.errors[:ts_msec]).to include('does not have the expected type [Time]')
+      end
+    end
+
+    context "timestamp-micros" do
+      it "accepts a Time" do
+        instance = test_class.new(ts_usec: Time.now)
+        instance.validate
+        expect(instance.errors[:ts_usec]).to be_empty
+      end
+
+      it "accepts an ActiveSupport::TimeWithZone" do
+        Time.zone = 'GMT'
+        instance = test_class.new(ts_usec: Time.zone.now)
+        instance.validate
+        expect(instance.errors[:ts_usec]).to be_empty
+      end
+
+      it "validates that a timestamp-micros is a Time" do
+        instance = test_class.new(ts_usec: Date.today)
+        expect(instance).to be_invalid
+        expect(instance.errors[:ts_usec]).to include('does not have the expected type [Time]')
+      end
+    end
+
+    context "date" do
+      it "accepts a Date" do
+        instance = test_class.new(date: Date.today)
+        instance.validate
+        expect(instance.errors[:date]).to be_empty
+      end
+
+      it "accepts a Time" do
+        instance = test_class.new(date: Time.now)
+        instance.validate
+        expect(instance.errors[:date]).to be_empty
+      end
+
+      it "validates that a date is a Date" do
+        Time.zone = 'GMT'
+        instance = test_class.new(date: Time.zone.now)
+        expect(instance).to be_invalid
+        expect(instance.errors[:date]).to include('does not have the expected type [Date]')
+      end
     end
   end
 
@@ -116,6 +251,12 @@ describe Avromatic::Model::Builder, 'validation' do
         end
       end
 
+      it "validates nested records initialized with a hash" do
+        instance = test_class.new(sub: { i: 0 })
+        expect(instance).to be_invalid
+        expect(instance.errors[:sub]).to include(".s can't be blank")
+      end
+
       context "doubly nested record" do
         let(:schema) do
           Avro::Builder.build_schema do
@@ -133,6 +274,12 @@ describe Avromatic::Model::Builder, 'validation' do
           level1 = test_class.nested_models['level1']
           level2 = test_class.nested_models['level2']
           instance = test_class.new(sub: level1.new(sub_sub: level2.new))
+          expect(instance).to be_invalid
+          expect(instance.errors[:sub]).to include(".sub_sub.l can't be blank")
+        end
+
+        it "validates multiple levels of nesting initialized with a hash" do
+          instance = test_class.new(sub: { sub_sub: {} })
           expect(instance).to be_invalid
           expect(instance.errors[:sub]).to include(".sub_sub.l can't be blank")
         end
@@ -157,6 +304,21 @@ describe Avromatic::Model::Builder, 'validation' do
           data = [nested_model.new,
                   nested_model.new(x: 1),
                   nested_model.new(y: 2)]
+          instance = test_class.new(ary: data)
+          expect(instance).to be_invalid
+          aggregate_failures do
+            expect(instance.errors[:ary]).to include("[0].x can't be blank")
+            expect(instance.errors[:ary]).to include("[0].y can't be blank")
+            expect(instance.errors[:ary]).to include("[1].y can't be blank")
+            expect(instance.errors[:ary]).to include("[2].x can't be blank")
+          end
+        end
+
+        it "validates records in an array initialized with hashes" do
+          nested_model = test_class.nested_models['x_and_y']
+          data = [{},
+                  { x: 1 },
+                  { y: 2 }]
           instance = test_class.new(ary: data)
           expect(instance).to be_invalid
           aggregate_failures do
@@ -226,6 +388,23 @@ describe Avromatic::Model::Builder, 'validation' do
             expect(instance.errors[:map]).to include("['c'].y can't be blank")
           end
         end
+
+        it "validates records in a map initialized with hashes" do
+          nested_model = test_class.nested_models['x_and_y']
+          data = {
+            a: { y: 3 },
+            b: {},
+            c: { x: 4 }
+          }
+          instance = test_class.new(map: data)
+          expect(instance).to be_invalid
+          aggregate_failures do
+            expect(instance.errors[:map]).to include("['a'].x can't be blank")
+            expect(instance.errors[:map]).to include("['b'].y can't be blank")
+            expect(instance.errors[:map]).to include("['b'].y can't be blank")
+            expect(instance.errors[:map]).to include("['c'].y can't be blank")
+          end
+        end
       end
 
       context "record in a union" do
@@ -250,6 +429,19 @@ describe Avromatic::Model::Builder, 'validation' do
             expect(instance.errors[:u]).to include(".x can't be blank")
             expect(instance.errors[:u]).to include(".y can't be blank")
           end
+        end
+
+        it "validates a record in a union initialized with hashes" do
+          expect(test_class.new(u: { x: 1, y: 2 })).to be_valid
+          instance = test_class.new(u: {})
+          expect(instance).to be_invalid
+          expect(instance.errors[:u]).to include("can't be blank")
+        end
+
+        it "validates a record in a union initialized with incomplete hashes" do
+          instance = test_class.new(u: { x: 1 })
+          expect(instance).to be_invalid
+          expect(instance.errors[:u]).to include("can't be blank")
         end
       end
     end

--- a/spec/avromatic/model/builder_validation_spec.rb
+++ b/spec/avromatic/model/builder_validation_spec.rb
@@ -315,7 +315,6 @@ describe Avromatic::Model::Builder, 'validation' do
         end
 
         it "validates records in an array initialized with hashes" do
-          nested_model = test_class.nested_models['x_and_y']
           data = [{},
                   { x: 1 },
                   { y: 2 }]
@@ -390,7 +389,6 @@ describe Avromatic::Model::Builder, 'validation' do
         end
 
         it "validates records in a map initialized with hashes" do
-          nested_model = test_class.nested_models['x_and_y']
           data = {
             a: { y: 3 },
             b: {},


### PR DESCRIPTION
This change improves assignment to subrecords using a hash. Previously, if the resulting subrecord was invalid, it would be set to nil. This change allows the subrecord to be partially assigned which improves validation and error handling because we then know exactly which fields are missing.

This change does not apply to records in unions. Improves could be made there in the future to find the "best" match among invalid values, but for now records in unions remain unassigned if they are invalid.

One quirk of Virtus that is also addressed here is that it will assign an invalid value to a primitive type, if if it is unable to coerce the value. 

Members of a union are now required to be the correct type after a coercion. E.g. previously an invalid hash for a record in a union could be assigned to a string type in a union.

Since Virtus will potentially assign invalid values to fields with primitive types, validation is not added to check that values for these fields have the expected type. Outside of unions, these fields are still assigned the invalid value but now the resulting model will fail validation.

This looks like a big change, but the majority is test coverage. Coverage for subrecord assignment from a hash was particularly lacking. 

Prime: @jkapell 
