### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## v1.0.0
+- No changes.
+
 ## v0.33.0
 - Fix compatibility with avro-patches v0.4.0.
 

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,3 @@
 module Avromatic
-  VERSION = '0.33.0'.freeze
+  VERSION = '1.0.0'.freeze
 end


### PR DESCRIPTION
This is just a version bump to 1.0.0 in preparation for landing the compatibility breaking Virtus replacement (i.e. #89 and friends) in 2.0.