### PR TITLE
Prevent model instances from being constructed with unknown attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v2.0.0 (unreleased)
 - Removed Virtus dependency.
+- Raise `Avromatic::Model::CoercionError` when attribute values can't be coerced to the target type.
+- Prevent model instances from being constructed with unknown attributes by default.
 - Support for custom types in unions with more than one non-null type.
 
 ## v1.0.0

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Avromatic with unreleased Avro features.
   `Avromatic.configure` and during code reloading in Rails applications. This
   option is useful for defining models that will be extended when the load order
   is important.
+* **allow_unknown_attributes**: Optionally allow model constructors to silently
+  ignore unknown attributes. Defaults to `false`.
 
 #### Custom Types
 
@@ -418,7 +420,9 @@ registry requests to a fake, in-memory schema registry and rebuilds the
 
 ## Upgrading to 2.0
 
-TODO
+TODO:
+* Validation in initialize/setters
+* Unknown attributes not allowed 
 
 ## Development
 

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -13,7 +13,7 @@ module Avromatic
     attr_accessor :schema_registry, :registry_url, :schema_store, :logger,
                   :messaging, :custom_type_registry, :nested_models,
                   :use_custom_datum_reader, :use_custom_datum_writer,
-                  :use_schema_fingerprint_lookup
+                  :use_schema_fingerprint_lookup, :allow_unknown_attributes
 
     delegate :register_type, to: :custom_type_registry
   end
@@ -24,6 +24,7 @@ module Avromatic
   self.use_custom_datum_reader = true
   self.use_custom_datum_writer = true
   self.use_schema_fingerprint_lookup = true
+  self.allow_unknown_attributes = false
 
   def self.configure
     yield self

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -42,17 +42,23 @@ module Avromatic
       end
 
       def initialize(data = {})
-        # TODO: Validate keys
+        valid_keys = []
         attribute_definitions.each do |attribute_name, attribute_definition|
           if data.include?(attribute_name)
+            valid_keys << attribute_name
             value = data.fetch(attribute_name)
             _attributes[attribute_name] = attribute_definition.coerce(value)
           elsif data.include?(attribute_name.to_s)
+            valid_keys << attribute_name
             value = data[attribute_name.to_s]
             _attributes[attribute_name] = attribute_definition.coerce(value)
           elsif !attributes.include?(attribute_name)
             _attributes[attribute_name] = attribute_definition.default
           end
+        end
+
+        unless Avromatic.allow_unknown_attributes || valid_keys.size == data.size
+          raise ArgumentError.new("Unexpected attributes for #{self.class.name}: #{(data.keys - valid_keys).map(&:to_s).join(', ')}. Complete arguments: #{data}")
         end
       end
 

--- a/spec/avromatic/io/datum_writer_spec.rb
+++ b/spec/avromatic/io/datum_writer_spec.rb
@@ -6,7 +6,6 @@ describe Avromatic::IO::DatumWriter do
   end
   let(:values) do
     {
-      headers: 'has bar',
       message: { bar_message: 'bar' }
     }
   end

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -378,6 +378,21 @@ describe Avromatic::Model::Builder do
     it_behaves_like "a reader of attribute values", :attributes
   end
 
+  describe "#initialize" do
+    let(:schema_name) { 'test.primitive_types' }
+
+    it "raises an ArgumentError when passed an unknown attribute when allow_unknown_attributes is false" do
+      expect do
+        test_class.new(unknown: true)
+      end.to raise_error(ArgumentError, 'Unexpected attributes for PrimitiveType: unknown. Complete arguments: {:unknown=>true}')
+    end
+
+    it "does not raise an ArgumentError when passed an unknown attribute when allow_unknown_attributes is true" do
+      allow(Avromatic).to receive(:allow_unknown_attributes).and_return(true)
+      expect { test_class.new(unknown: true) }.not_to raise_error
+    end
+  end
+
   context "coercion" do
     # This is important for the eventual encoding of a model to Avro
 


### PR DESCRIPTION
This raises an exception if a model instance is constructed with unknown attributes. This behavior can be disabled by setting `Avromatic.allow_unknown_attributes = false`. It's already uncovered some bugs in the Salsify codebase :)