### PR TITLE
Better coercion error messages

### DIFF
--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -19,10 +19,11 @@ module Avromatic
       end
 
       class AttributeDefinition
-        attr_reader :name, :type, :field, :default
-        delegate :coerce, :serialize, to: :type
+        attr_reader :name, :type, :field, :default, :owner
+        delegate :serialize, to: :type
 
-        def initialize(field:, type:)
+        def initialize(owner:, field:, type:)
+          @owner = owner
           @field = field
           @type = type
           @name = field.name.to_sym
@@ -33,6 +34,12 @@ module Avromatic
                      else
                        field.default
                      end
+        end
+
+        def coerce(input)
+          type.coerce(input)
+        rescue StandardError
+          raise Avromatic::Model::CoercionError.new("Could not coerce '#{input.inspect}' to #{type.name} when setting #{owner.name}##{name}")
         end
       end
 
@@ -126,6 +133,7 @@ module Avromatic
 
             symbolized_field_name = field.name.to_sym
             attribute_definition = AttributeDefinition.new(
+              owner: self,
               field: field,
               type: create_type(field)
             )

--- a/lib/avromatic/model/types/abstract_timestamp_type.rb
+++ b/lib/avromatic/model/types/abstract_timestamp_type.rb
@@ -14,7 +14,7 @@ module Avromatic
           elsif input.is_a?(::Time) || input.is_a?(::DateTime)
             coerce_time(input)
           else
-            raise Avromatic::Model::CoercionError.new("Could not coerce '#{input.inspect}' to #{self.class.name.demodulize}")
+            raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")
           end
         end
 

--- a/lib/avromatic/model/types/array_type.rb
+++ b/lib/avromatic/model/types/array_type.rb
@@ -14,7 +14,7 @@ module Avromatic
         end
 
         def name
-          "array[#{value_type.name}]"
+          "array[#{value_type.name}]".freeze
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/array_type.rb
+++ b/lib/avromatic/model/types/array_type.rb
@@ -13,13 +13,17 @@ module Avromatic
           VALUE_CLASSES
         end
 
+        def name
+          "array[#{value_type.name}]"
+        end
+
         def coerce(input)
           if input.nil?
             input
           elsif input.is_a?(::Array)
             input.map { |element_input| value_type.coerce(element_input) }
           else
-            raise Avromatic::Model::CoercionError.new("Could not coerce '#{input.inspect}' to an Array")
+            raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")
           end
         end
 

--- a/lib/avromatic/model/types/boolean_type.rb
+++ b/lib/avromatic/model/types/boolean_type.rb
@@ -9,7 +9,7 @@ module Avromatic
         end
 
         def name
-          'boolean'
+          'boolean'.freeze
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/boolean_type.rb
+++ b/lib/avromatic/model/types/boolean_type.rb
@@ -8,11 +8,15 @@ module Avromatic
           VALUE_CLASSES
         end
 
+        def name
+          'boolean'
+        end
+
         def coerce(input)
           if coercible?(input)
             input
           else
-            raise Avromatic::Model::CoercionError.new("Could not coerce '#{input.inspect}' to a Boolean")
+            raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")
           end
         end
 

--- a/lib/avromatic/model/types/custom_type.rb
+++ b/lib/avromatic/model/types/custom_type.rb
@@ -4,17 +4,22 @@ module Avromatic
       class CustomType
         IDENTITY_PROC = Proc.new { |value| value }
 
-        attr_reader :custom_type_configuration, :value_classes
+        attr_reader :custom_type_configuration, :value_classes, :default_type
 
-        def initialize(custom_type_configuration:, default_value_classes:)
+        def initialize(custom_type_configuration:, default_type:)
           @custom_type_configuration = custom_type_configuration
+          @default_type = default_type
           @deserializer = custom_type_configuration.deserializer || IDENTITY_PROC
           @serializer = custom_type_configuration.serializer || IDENTITY_PROC
           @value_classes = if custom_type_configuration.value_class
                              [custom_type_configuration.value_class].freeze
                            else
-                             default_value_classes
+                             default_type.value_classes
                            end
+        end
+
+        def name
+          custom_type_configuration.value_class ? custom_type_configuration.value_class.name.to_s : default_type.name
         end
 
         def coerce(input)
@@ -24,20 +29,20 @@ module Avromatic
             @deserializer.call(input)
           end
         rescue StandardError => e
-          raise Avromatic::Model::CoercionError.new("Could not coerce '#{input.inspect}' to a #{value_classes.map(&:name).join(', ')}: #{e.message}")
+          raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}: #{e.message}")
         end
 
         def coercible?(input)
           # TODO: Delegate this to optional configuration
           input.nil? || !coerce(input).nil?
-        rescue Avromatic::Model::CoercionError
+        rescue ArgumentError
           false
         end
 
         def coerced?(value)
           # TODO: Delegate this to optional configuration
           coerce(value) == value
-        rescue Avromatic::Model::CoercionError
+        rescue ArgumentError
           false
         end
 

--- a/lib/avromatic/model/types/custom_type.rb
+++ b/lib/avromatic/model/types/custom_type.rb
@@ -19,7 +19,7 @@ module Avromatic
         end
 
         def name
-          custom_type_configuration.value_class ? custom_type_configuration.value_class.name.to_s : default_type.name
+          custom_type_configuration.value_class ? custom_type_configuration.value_class.name.to_s.freeze : default_type.name
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/date_type.rb
+++ b/lib/avromatic/model/types/date_type.rb
@@ -9,7 +9,7 @@ module Avromatic
         end
 
         def name
-          'date'
+          'date'.freeze
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/date_type.rb
+++ b/lib/avromatic/model/types/date_type.rb
@@ -8,13 +8,17 @@ module Avromatic
           VALUE_CLASSES
         end
 
+        def name
+          'date'
+        end
+
         def coerce(input)
           if input.is_a?(::Time) || input.is_a?(::DateTime)
             ::Date.new(input.year, input.month, input.day)
           elsif input.nil? || input.is_a?(::Date)
             input
           else
-            raise Avromatic::Model::CoercionError.new("Could not coerce '#{input.inspect}' to a Date")
+            raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")
           end
         end
 

--- a/lib/avromatic/model/types/enum_type.rb
+++ b/lib/avromatic/model/types/enum_type.rb
@@ -10,6 +10,10 @@ module Avromatic
           @allowed_values = allowed_values.to_set
         end
 
+        def name
+          "enum#{allowed_values.to_a}"
+        end
+
         def value_classes
           VALUE_CLASSES
         end
@@ -20,7 +24,7 @@ module Avromatic
           elsif coercible?(input)
             input.to_s
           else
-            raise Avromatic::Model::CoercionError.new("Could not coerce '#{input.inspect}' to an Enum(#{allowed_values.to_a.join(',')})")
+            raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")
           end
         end
 

--- a/lib/avromatic/model/types/enum_type.rb
+++ b/lib/avromatic/model/types/enum_type.rb
@@ -11,7 +11,7 @@ module Avromatic
         end
 
         def name
-          "enum#{allowed_values.to_a}"
+          "enum#{allowed_values.to_a}".freeze
         end
 
         def value_classes

--- a/lib/avromatic/model/types/fixed_type.rb
+++ b/lib/avromatic/model/types/fixed_type.rb
@@ -10,6 +10,10 @@ module Avromatic
           @size = size
         end
 
+        def name
+          "fixed(#{size})"
+        end
+
         def value_classes
           VALUE_CLASSES
         end
@@ -18,7 +22,7 @@ module Avromatic
           if coercible?(input)
             input
           else
-            raise Avromatic::Model::CoercionError.new("Could not coerce '#{input.inspect}' to a Fixed(#{size})")
+            raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")
           end
         end
 

--- a/lib/avromatic/model/types/fixed_type.rb
+++ b/lib/avromatic/model/types/fixed_type.rb
@@ -11,7 +11,7 @@ module Avromatic
         end
 
         def name
-          "fixed(#{size})"
+          "fixed(#{size})".freeze
         end
 
         def value_classes

--- a/lib/avromatic/model/types/float_type.rb
+++ b/lib/avromatic/model/types/float_type.rb
@@ -9,7 +9,7 @@ module Avromatic
         end
 
         def name
-          'float'
+          'float'.freeze
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/float_type.rb
+++ b/lib/avromatic/model/types/float_type.rb
@@ -8,13 +8,17 @@ module Avromatic
           VALUE_CLASSES
         end
 
+        def name
+          'float'
+        end
+
         def coerce(input)
           if input.nil? || input.is_a?(::Float)
             input
           elsif input.is_a?(::Integer)
             input.to_f
           else
-            raise Avromatic::Model::CoercionError.new("Could not coerce '#{input.inspect}' to a Float")
+            raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")
           end
         end
 

--- a/lib/avromatic/model/types/integer_type.rb
+++ b/lib/avromatic/model/types/integer_type.rb
@@ -8,11 +8,15 @@ module Avromatic
           VALUE_CLASSES
         end
 
+        def name
+          'integer'
+        end
+
         def coerce(input)
           if input.nil? || input.is_a?(::Integer)
             input
           else
-            raise Avromatic::Model::CoercionError.new("Could not coerce '#{input.inspect}' to an Integer")
+            raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")
           end
         end
 

--- a/lib/avromatic/model/types/integer_type.rb
+++ b/lib/avromatic/model/types/integer_type.rb
@@ -9,7 +9,7 @@ module Avromatic
         end
 
         def name
-          'integer'
+          'integer'.freeze
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/map_type.rb
+++ b/lib/avromatic/model/types/map_type.rb
@@ -11,6 +11,10 @@ module Avromatic
           @value_type = value_type
         end
 
+        def name
+          "map[#{key_type.name} => #{value_type.name}]"
+        end
+
         def value_classes
           VALUE_CLASSES
         end
@@ -23,7 +27,7 @@ module Avromatic
               result[key_type.coerce(key_input)] = value_type.coerce(value_input)
             end
           else
-            raise Avromatic::Model::CoercionError.new("Could not coerce '#{input.inspect}' to a Map")
+            raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")
           end
         end
 

--- a/lib/avromatic/model/types/map_type.rb
+++ b/lib/avromatic/model/types/map_type.rb
@@ -12,7 +12,7 @@ module Avromatic
         end
 
         def name
-          "map[#{key_type.name} => #{value_type.name}]"
+          "map[#{key_type.name} => #{value_type.name}]".freeze
         end
 
         def value_classes

--- a/lib/avromatic/model/types/null_type.rb
+++ b/lib/avromatic/model/types/null_type.rb
@@ -8,11 +8,15 @@ module Avromatic
           VALUE_CLASSES
         end
 
+        def name
+          'null'
+        end
+
         def coerce(input)
           if input.nil?
             nil
           else
-            raise Avromatic::Model::CoercionError.new("Could not coerce '#{input.inspect}' to a Null")
+            raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")
           end
         end
 

--- a/lib/avromatic/model/types/null_type.rb
+++ b/lib/avromatic/model/types/null_type.rb
@@ -9,7 +9,7 @@ module Avromatic
         end
 
         def name
-          'null'
+          'null'.freeze
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/record_type.rb
+++ b/lib/avromatic/model/types/record_type.rb
@@ -9,20 +9,24 @@ module Avromatic
           @value_classes = [record_class].freeze
         end
 
+        def name
+          record_class.name.to_s
+        end
+
         def coerce(input)
           if input.nil? || input.is_a?(record_class)
             input
           elsif input.is_a?(Hash)
             record_class.new(input)
           else
-            raise Avromatic::Model::CoercionError.new("Could not coerce '#{input.inspect}' to a #{record_class}")
+            raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")
           end
         end
 
         def coercible?(input)
           # TODO: Is there a better way to figure this out?
           input.nil? || input.is_a?(record_class) || coerce(input).valid?
-        rescue Avromatic::Model::CoercionError
+        rescue StandardError
           false
         end
 

--- a/lib/avromatic/model/types/record_type.rb
+++ b/lib/avromatic/model/types/record_type.rb
@@ -10,7 +10,7 @@ module Avromatic
         end
 
         def name
-          record_class.name.to_s
+          record_class.name.to_s.freeze
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/string_type.rb
+++ b/lib/avromatic/model/types/string_type.rb
@@ -9,7 +9,7 @@ module Avromatic
         end
 
         def name
-          'string'
+          'string'.freeze
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/string_type.rb
+++ b/lib/avromatic/model/types/string_type.rb
@@ -8,13 +8,17 @@ module Avromatic
           VALUE_CLASSES
         end
 
+        def name
+          'string'
+        end
+
         def coerce(input)
           if input.nil? || input.is_a?(::String)
             input
           elsif input.is_a?(::Symbol)
             input.to_s
           else
-            raise Avromatic::Model::CoercionError.new("Could not coerce '#{input.inspect}' to a String")
+            raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")
           end
         end
 

--- a/lib/avromatic/model/types/timestamp_micros_type.rb
+++ b/lib/avromatic/model/types/timestamp_micros_type.rb
@@ -8,7 +8,7 @@ module Avromatic
       class TimestampMicrosType < Avromatic::Model::Types::AbstractTimestampType
 
         def name
-          'timestamp-micros'
+          'timestamp-micros'.freeze
         end
 
         def coerced?(value)

--- a/lib/avromatic/model/types/timestamp_micros_type.rb
+++ b/lib/avromatic/model/types/timestamp_micros_type.rb
@@ -7,6 +7,10 @@ module Avromatic
       # This subclass is used to truncate timestamp values to microseconds.
       class TimestampMicrosType < Avromatic::Model::Types::AbstractTimestampType
 
+        def name
+          'timestamp-micros'
+        end
+
         def coerced?(value)
           value.is_a?(::Time) && value.nsec % 1000 == 0
         end

--- a/lib/avromatic/model/types/timestamp_millis_type.rb
+++ b/lib/avromatic/model/types/timestamp_millis_type.rb
@@ -8,7 +8,7 @@ module Avromatic
       class TimestampMillisType < Avromatic::Model::Types::AbstractTimestampType
 
         def name
-          'timestamp-millis'
+          'timestamp-millis'.freeze
         end
 
         def coerced?(value)

--- a/lib/avromatic/model/types/timestamp_millis_type.rb
+++ b/lib/avromatic/model/types/timestamp_millis_type.rb
@@ -7,6 +7,10 @@ module Avromatic
       # This subclass is used to truncate timestamp values to milliseconds.
       class TimestampMillisType < Avromatic::Model::Types::AbstractTimestampType
 
+        def name
+          'timestamp-millis'
+        end
+
         def coerced?(value)
           value.is_a?(::Time) && value.usec % 1000 == 0
         end

--- a/lib/avromatic/model/types/type_factory.rb
+++ b/lib/avromatic/model/types/type_factory.rb
@@ -37,14 +37,14 @@ module Avromatic
         def create(schema:, nested_models:, use_custom_types: true)
           if use_custom_types && Avromatic.custom_type_registry.registered?(schema)
             custom_type_configuration = Avromatic.custom_type_registry.fetch(schema)
-            default_value_classes = create(
+            default_type = create(
               schema: schema,
               nested_models: nested_models,
               use_custom_types: false
-            ).value_classes
+            )
             Avromatic::Model::Types::CustomType.new(
               custom_type_configuration: custom_type_configuration,
-              default_value_classes: default_value_classes
+              default_type: default_type
             )
           elsif schema.respond_to?(:logical_type) && SINGLETON_TYPES.include?(schema.logical_type)
             SINGLETON_TYPES.fetch(schema.logical_type)

--- a/lib/avromatic/model/types/union_type.rb
+++ b/lib/avromatic/model/types/union_type.rb
@@ -13,7 +13,7 @@ module Avromatic
         end
 
         def name
-          "union[#{member_types.map(&:name).join(', ')}]"
+          "union[#{member_types.map(&:name).join(', ')}]".freeze
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/union_type.rb
+++ b/lib/avromatic/model/types/union_type.rb
@@ -12,6 +12,10 @@ module Avromatic
           @value_classes = member_types.flat_map(&:value_classes)
         end
 
+        def name
+          "union[#{member_types.map(&:name).join(', ')}]"
+        end
+
         def coerce(input)
           return input if coerced?(input)
 
@@ -25,7 +29,7 @@ module Avromatic
           end
 
           unless result
-            raise Avromatic::Model::CoercionError.new("Could not coerce '#{input.inspect}' to a union of #{value_classes.map(&:name)}")
+            raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")
           end
 
           result


### PR DESCRIPTION
This PR improves coercion error messages by giving more context on the location of the coercion error. Here are some examples:

```
# Primitive coercion errors
# Before
Could not coerce '1' to a String
# After
Could not coerce '1' to string when setting Core::Events::DigitalAsset#url

# Custom type coercion errors
# Before
Could not coerce '1' to a SalsifyUuid: Value is not a valid Salsify UUID: '1'
# After
Could not coerce '1' to SalsifyUuid when setting Core::Events::Product#id

# Array coercion errors
# Before
Could not coerce '"foobar"' to a SalsifyUuid: Value is not a valid Salsify UUID: 'foobar'
# After
Could not coerce '["foobar"]' to array[SalsifyUuid] when setting ComputedProperty#formula_reference_property_ids

# Union coercion errors
# Before
Could not coerce '{:id=>1}' to a union of ["Core::Events::Product", "Core::Events::DigitalAsset"]
# After
Could not coerce '{:id=>1}' to union[Core::Events::Product, Core::Events::DigitalAsset] when setting Subscriptions::EntityChangedEvent#entity

# Map coercion errors
# Before
Could not coerce '1' to a String
# After
Could not coerce '{:id=>1}' to map[string => string] when setting Subscriptions::EntityChangedEvent#subscription_correlations
```
Note exceptions will still be properly chained for scenarios where there's an underlying exception (e.g custom type coercion).

Fixes #93.

@tjwp - you're prime
/cc @jkapell 