### PR TITLE
Drop support for Ruby < 2.3 and Rails < 5.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,10 +2,13 @@ inherit_gem:
   salsify_rubocop: conf/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Style/MultilineBlockChain:
   Enabled: false
 
 Style/NumericPredicate:
   Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: true

--- a/Appraisals
+++ b/Appraisals
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 appraise 'rails5_0' do
   gem 'avro', '1.8.2'
   gem 'activesupport', '~> 5.0.6'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Raise `Avromatic::Model::CoercionError` when attribute values can't be coerced to the target type.
 - Prevent model instances from being constructed with unknown attributes by default.
 - Support for custom types in unions with more than one non-null type.
+- Drop support for Ruby < 2.3 and Rails < 5.0.
 
 ## v1.0.0
 - No changes.

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in avromatic.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'appraisal/task'

--- a/avromatic.gemspec
+++ b/avromatic.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'avromatic/version'
@@ -18,8 +20,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activemodel', '>= 4.1', '< 5.3'
-  spec.add_runtime_dependency 'activesupport', '>= 4.1', '< 5.3'
+  spec.required_ruby_version = '>= 2.3'
+
+  spec.add_runtime_dependency 'activemodel', '>= 5.0', '< 5.3'
+  spec.add_runtime_dependency 'activesupport', '>= 5.0', '< 5.3'
   spec.add_runtime_dependency 'avro', '>= 1.7.7'
   spec.add_runtime_dependency 'avro_schema_registry-client', '>= 0.3.0'
   spec.add_runtime_dependency 'avro_turf'

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avromatic/version'
 require 'avro_schema_registry-client'
 require 'ice_nine'

--- a/lib/avromatic/io.rb
+++ b/lib/avromatic/io.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Avromatic
   module IO
-    UNION_MEMBER_INDEX = '__avromatic_member_index'.freeze
-    ENCODING_PROVIDER = '__avromatic_encoding_provider'.freeze
+    UNION_MEMBER_INDEX = '__avromatic_member_index'
+    ENCODING_PROVIDER = '__avromatic_encoding_provider'
   end
 end
 

--- a/lib/avromatic/io/datum_reader.rb
+++ b/lib/avromatic/io/datum_reader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop:disable Style/WhenThen
 module Avromatic
   module IO

--- a/lib/avromatic/io/datum_writer.rb
+++ b/lib/avromatic/io/datum_writer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module IO
     # Subclass DatumWriter to use additional information about union member

--- a/lib/avromatic/messaging.rb
+++ b/lib/avromatic/messaging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avro_turf/messaging'
 require 'avromatic/io'
 

--- a/lib/avromatic/model.rb
+++ b/lib/avromatic/model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avromatic/model/builder'
 require 'avromatic/model/coercion_error'
 require 'avromatic/model/message_decoder'

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/object/duplicable'
 require 'active_support/time'
 

--- a/lib/avromatic/model/builder.rb
+++ b/lib/avromatic/model/builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/concern'
 require 'active_model'
 require 'avromatic/model/configuration'

--- a/lib/avromatic/model/coercion_error.rb
+++ b/lib/avromatic/model/coercion_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
     class CoercionError < StandardError

--- a/lib/avromatic/model/configurable.rb
+++ b/lib/avromatic/model/configurable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
 

--- a/lib/avromatic/model/configuration.rb
+++ b/lib/avromatic/model/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
 

--- a/lib/avromatic/model/custom_type_configuration.rb
+++ b/lib/avromatic/model/custom_type_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
 

--- a/lib/avromatic/model/custom_type_registry.rb
+++ b/lib/avromatic/model/custom_type_registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avromatic/model/custom_type_configuration'
 
 module Avromatic

--- a/lib/avromatic/model/message_decoder.rb
+++ b/lib/avromatic/model/message_decoder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
 

--- a/lib/avromatic/model/messaging_serialization.rb
+++ b/lib/avromatic/model/messaging_serialization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
 

--- a/lib/avromatic/model/nested_models.rb
+++ b/lib/avromatic/model/nested_models.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/inflector/methods'
 
 module Avromatic

--- a/lib/avromatic/model/raw_serialization.rb
+++ b/lib/avromatic/model/raw_serialization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
 

--- a/lib/avromatic/model/types/abstract_timestamp_type.rb
+++ b/lib/avromatic/model/types/abstract_timestamp_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
     module Types

--- a/lib/avromatic/model/types/array_type.rb
+++ b/lib/avromatic/model/types/array_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
     module Types
@@ -14,7 +16,7 @@ module Avromatic
         end
 
         def name
-          "array[#{value_type.name}]".freeze
+          "array[#{value_type.name}]"
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/boolean_type.rb
+++ b/lib/avromatic/model/types/boolean_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
     module Types
@@ -9,7 +11,7 @@ module Avromatic
         end
 
         def name
-          'boolean'.freeze
+          'boolean'
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/custom_type.rb
+++ b/lib/avromatic/model/types/custom_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
     module Types

--- a/lib/avromatic/model/types/date_type.rb
+++ b/lib/avromatic/model/types/date_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
     module Types
@@ -9,7 +11,7 @@ module Avromatic
         end
 
         def name
-          'date'.freeze
+          'date'
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/enum_type.rb
+++ b/lib/avromatic/model/types/enum_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
     module Types
@@ -11,7 +13,7 @@ module Avromatic
         end
 
         def name
-          "enum#{allowed_values.to_a}".freeze
+          "enum#{allowed_values.to_a}"
         end
 
         def value_classes

--- a/lib/avromatic/model/types/fixed_type.rb
+++ b/lib/avromatic/model/types/fixed_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
     module Types
@@ -11,7 +13,7 @@ module Avromatic
         end
 
         def name
-          "fixed(#{size})".freeze
+          "fixed(#{size})"
         end
 
         def value_classes

--- a/lib/avromatic/model/types/float_type.rb
+++ b/lib/avromatic/model/types/float_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
     module Types
@@ -9,7 +11,7 @@ module Avromatic
         end
 
         def name
-          'float'.freeze
+          'float'
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/integer_type.rb
+++ b/lib/avromatic/model/types/integer_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
     module Types
@@ -9,7 +11,7 @@ module Avromatic
         end
 
         def name
-          'integer'.freeze
+          'integer'
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/map_type.rb
+++ b/lib/avromatic/model/types/map_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
     module Types
@@ -12,7 +14,7 @@ module Avromatic
         end
 
         def name
-          "map[#{key_type.name} => #{value_type.name}]".freeze
+          "map[#{key_type.name} => #{value_type.name}]"
         end
 
         def value_classes

--- a/lib/avromatic/model/types/null_type.rb
+++ b/lib/avromatic/model/types/null_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
     module Types
@@ -9,7 +11,7 @@ module Avromatic
         end
 
         def name
-          'null'.freeze
+          'null'
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/record_type.rb
+++ b/lib/avromatic/model/types/record_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
     module Types

--- a/lib/avromatic/model/types/string_type.rb
+++ b/lib/avromatic/model/types/string_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
     module Types
@@ -9,7 +11,7 @@ module Avromatic
         end
 
         def name
-          'string'.freeze
+          'string'
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/timestamp_micros_type.rb
+++ b/lib/avromatic/model/types/timestamp_micros_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avromatic/model/types/abstract_timestamp_type'
 
 module Avromatic
@@ -8,7 +10,7 @@ module Avromatic
       class TimestampMicrosType < Avromatic::Model::Types::AbstractTimestampType
 
         def name
-          'timestamp-micros'.freeze
+          'timestamp-micros'
         end
 
         def coerced?(value)

--- a/lib/avromatic/model/types/timestamp_millis_type.rb
+++ b/lib/avromatic/model/types/timestamp_millis_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avromatic/model/types/abstract_timestamp_type'
 
 module Avromatic
@@ -8,7 +10,7 @@ module Avromatic
       class TimestampMillisType < Avromatic::Model::Types::AbstractTimestampType
 
         def name
-          'timestamp-millis'.freeze
+          'timestamp-millis'
         end
 
         def coerced?(value)

--- a/lib/avromatic/model/types/type_factory.rb
+++ b/lib/avromatic/model/types/type_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avromatic/model/types/array_type'
 require 'avromatic/model/types/boolean_type'
 require 'avromatic/model/types/custom_type'

--- a/lib/avromatic/model/types/union_type.rb
+++ b/lib/avromatic/model/types/union_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avromatic/io'
 
 module Avromatic
@@ -13,7 +15,7 @@ module Avromatic
         end
 
         def name
-          "union[#{member_types.map(&:name).join(', ')}]".freeze
+          "union[#{member_types.map(&:name).join(', ')}]"
         end
 
         def coerce(input)

--- a/lib/avromatic/model/validation.rb
+++ b/lib/avromatic/model/validation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
     module Validation

--- a/lib/avromatic/model/value_object.rb
+++ b/lib/avromatic/model/value_object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Model
     # This module is used to override the comparisons defined by

--- a/lib/avromatic/model_registry.rb
+++ b/lib/avromatic/model_registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/string/access'
 
 module Avromatic

--- a/lib/avromatic/patches.rb
+++ b/lib/avromatic/patches.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 loaded_avro_patches = begin
     require 'avro-patches'
     true

--- a/lib/avromatic/patches/schema_validator_patch.rb
+++ b/lib/avromatic/patches/schema_validator_patch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   module Patches
     module SchemaValidatorPatch

--- a/lib/avromatic/railtie.rb
+++ b/lib/avromatic/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
   class Railtie < Rails::Railtie
     initializer 'avromatic.configure' do

--- a/lib/avromatic/rspec.rb
+++ b/lib/avromatic/rspec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'webmock/rspec'
 require 'avro_schema_registry/test/fake_server'
 

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Avromatic
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.0'
 end

--- a/spec/avro/dsl/test/defaults.rb
+++ b/spec/avro/dsl/test/defaults.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace 'test'
 
 record :defaults do

--- a/spec/avro/dsl/test/encode_key.rb
+++ b/spec/avro/dsl/test/encode_key.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 record :encode_key, namespace: :test do
   required :id, :int
 end

--- a/spec/avro/dsl/test/encode_value.rb
+++ b/spec/avro/dsl/test/encode_value.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 record :encode_value, namespace: :test do
   required :str1, :string, default: 'X'
   required :str2, :string, default: 'Y'

--- a/spec/avro/dsl/test/key.rb
+++ b/spec/avro/dsl/test/key.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace 'test'
 
 record :key do

--- a/spec/avro/dsl/test/key_conflict.rb
+++ b/spec/avro/dsl/test/key_conflict.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 record :key_conflict, namespace: 'test' do
   required :id, :bytes
   required :b, :string

--- a/spec/avro/dsl/test/key_overlap.rb
+++ b/spec/avro/dsl/test/key_overlap.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 record :key_overlap, namespace: 'test' do
   required :id, :long
   required :b, :string

--- a/spec/avro/dsl/test/key_with_optional.rb
+++ b/spec/avro/dsl/test/key_with_optional.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 record :key_with_optional, namespace: :test do
   required :id, :long
   optional :name, :string

--- a/spec/avro/dsl/test/logical_types.rb
+++ b/spec/avro/dsl/test/logical_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 record :logical_types, namespace: :test do
   required :date, :int, logical_type: 'date'
   required :ts_msec, :long, logical_type: 'timestamp-millis'

--- a/spec/avro/dsl/test/named_fields.rb
+++ b/spec/avro/dsl/test/named_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace 'test'
 
 record :named_fields do

--- a/spec/avro/dsl/test/named_type.rb
+++ b/spec/avro/dsl/test/named_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :test
 
 fixed :six, size: 6

--- a/spec/avro/dsl/test/nested_record.rb
+++ b/spec/avro/dsl/test/nested_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :test
 
 record :nested_record do

--- a/spec/avro/dsl/test/null_in_union.rb
+++ b/spec/avro/dsl/test/null_in_union.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :test
 
 record :i_rec do

--- a/spec/avro/dsl/test/optional_array.rb
+++ b/spec/avro/dsl/test/optional_array.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :test
 
 record :message do

--- a/spec/avro/dsl/test/optional_record.rb
+++ b/spec/avro/dsl/test/optional_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :test
 
 record :message do

--- a/spec/avro/dsl/test/optional_union.rb
+++ b/spec/avro/dsl/test/optional_union.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :test
 
 record :foo do

--- a/spec/avro/dsl/test/primitive_types.rb
+++ b/spec/avro/dsl/test/primitive_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :test
 
 record :primitive_types do

--- a/spec/avro/dsl/test/real_union.rb
+++ b/spec/avro/dsl/test/real_union.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :test
 
 record :foo do

--- a/spec/avro/dsl/test/recursive.rb
+++ b/spec/avro/dsl/test/recursive.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 record :recursive, namespace: :test do
   required :s, :string
   optional :child, :recursive

--- a/spec/avro/dsl/test/repeated_name.rb
+++ b/spec/avro/dsl/test/repeated_name.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :test
 
 record :sub do

--- a/spec/avro/dsl/test/value.rb
+++ b/spec/avro/dsl/test/value.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 record :value, namespace: :test do
   required :action, :enum, symbols: %i(CREATE UPDATE DESTROY)
   required :id, :long

--- a/spec/avro/dsl/test/with_array.rb
+++ b/spec/avro/dsl/test/with_array.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 record :with_array, namespace: :test do
   required :names, :array, items: :string, default: ['first']
 end

--- a/spec/avro/dsl/test/with_map.rb
+++ b/spec/avro/dsl/test/with_map.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 record :with_map, namespace: :test do
   required :pairs, :map, values: :int, default: { a: 1 }
 end

--- a/spec/avro/dsl/test/with_union.rb
+++ b/spec/avro/dsl/test/with_union.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 record :with_union, namespace: :test do
   optional :s, :string
 end

--- a/spec/avro/dsl/test/with_varchar.rb
+++ b/spec/avro/dsl/test/with_varchar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :test
 
 record :varchar do

--- a/spec/avro/dsl/test/wrapper.rb
+++ b/spec/avro/dsl/test/wrapper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace 'test'
 
 record :wrapped1 do

--- a/spec/avromatic/io/datum_reader_spec.rb
+++ b/spec/avromatic/io/datum_reader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Avromatic::IO::DatumReader do
   let(:test_class) do
     Avromatic::Model.model(schema_name: schema_name)
@@ -67,7 +69,7 @@ describe Avromatic::IO::DatumReader do
     end
 
     it "includes the member index in the decoded hash" do
-      expect(attributes['message'][described_class::UNION_MEMBER_INDEX]).to eq(1)
+      expect(attributes.dig('message', described_class::UNION_MEMBER_INDEX)).to eq(1)
     end
 
     it "can decode a message" do
@@ -78,7 +80,7 @@ describe Avromatic::IO::DatumReader do
       let(:schema_name) { 'test.optional_union' }
 
       it "includes the member index in the decoded hash" do
-        expect(attributes['message'][described_class::UNION_MEMBER_INDEX]).to eq(1)
+        expect(attributes.dig('message', described_class::UNION_MEMBER_INDEX)).to eq(1)
       end
 
       it "can decode a message" do

--- a/spec/avromatic/io/datum_writer_spec.rb
+++ b/spec/avromatic/io/datum_writer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Avromatic::IO::DatumWriter do
   let(:encoder) { instance_double(Avro::IO::BinaryEncoder) }
   let(:schema_name) { 'test.real_union' }

--- a/spec/avromatic/model/builder_nested_models_spec.rb
+++ b/spec/avromatic/model/builder_nested_models_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Avromatic::Model::Builder, 'nested_models' do
   let(:schema) do
     Avro::Builder.build_schema do

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Avromatic::Model::Builder do
   let(:schema_store) { Avromatic.schema_store }
   let(:schema) { schema_store.find(schema_name) }

--- a/spec/avromatic/model/builder_validation_spec.rb
+++ b/spec/avromatic/model/builder_validation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Avromatic::Model::Builder, 'validation' do
   let(:schema) { schema_store.find(schema_name) }
   let(:test_class) do

--- a/spec/avromatic/model/message_decoder_spec.rb
+++ b/spec/avromatic/model/message_decoder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Avromatic::Model::MessageDecoder do

--- a/spec/avromatic/model/messaging_serialization_spec.rb
+++ b/spec/avromatic/model/messaging_serialization_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'avro/builder'
 
 describe Avromatic::Model::MessagingSerialization do

--- a/spec/avromatic/model/raw_serialization_spec.rb
+++ b/spec/avromatic/model/raw_serialization_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'avro/builder'
 

--- a/spec/avromatic/model_registry_spec.rb
+++ b/spec/avromatic/model_registry_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Avromatic::ModelRegistry do
   let(:model) { Avromatic::Model.model(schema_name: 'test.nested_record') }
   let(:instance) { described_class.new }

--- a/spec/avromatic/model_spec.rb
+++ b/spec/avromatic/model_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Avromatic::Model do

--- a/spec/avromatic_spec.rb
+++ b/spec/avromatic_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Avromatic do
   it "has a version number" do
     expect(Avromatic::VERSION).not_to be_nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'simplecov'
 

--- a/spec/support/contexts/logical_types_serialization.rb
+++ b/spec/support/contexts/logical_types_serialization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This examples expects let-variables to be defined for:
 #   decoded: a model instance based on the encoded_value
 shared_examples_for "logical type encoding and decoding" do

--- a/spec/support/helpers/logical_types_helper.rb
+++ b/spec/support/helpers/logical_types_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module LogicalTypesHelper
 
   def with_logical_types


### PR DESCRIPTION
This also adds the `# frozen_string_literal: true` pragma to all files.

/cc @jkapell 