### PR TITLE
Call super() in model constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   but errors will now appear under the `:base` key.  
 - Support for custom types in unions with more than one non-null type.
 - Drop support for Ruby < 2.3 and Rails < 5.0.
+- Call `super()` in model constructor.
 
 ## v1.0.0
 - No changes.

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -55,6 +55,8 @@ module Avromatic
       end
 
       def initialize(data = {})
+        super()
+
         valid_keys = []
         attribute_definitions.each do |attribute_name, attribute_definition|
           if data.include?(attribute_name)

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -393,6 +393,28 @@ describe Avromatic::Model::Builder do
       allow(Avromatic).to receive(:allow_unknown_attributes).and_return(true)
       expect { test_class.new(unknown: true) }.not_to raise_error
     end
+
+    context "when the model has a super class" do
+      let(:parent_class) do
+        Class.new do
+          attr_reader :parent_initialized
+          def initialize
+            @parent_initialized = true
+          end
+        end
+      end
+
+      let(:test_class) do
+        Class.new(parent_class) do
+          include Avromatic::Model.build(schema_name: 'test.primitive_types')
+        end
+      end
+
+      it "calls the super class' initialize method" do
+        instance = test_class.new(s: 's')
+        expect(instance.parent_initialized).to eq(true)
+      end
+    end
   end
 
   context "coercion" do


### PR DESCRIPTION
Now that the Virtus dependency has been removed we can call `super()` from the model constructor. This means we no longer have to play games with `prepend` and `inherited` callbacks in base event classes e.g.

```ruby
class AlertEvent
  def self.inherited(subclass)
    subclass.prepend(SalsifyAvro::MultitenantValue)
    subclass.prepend(SalsifyAvro::UniquelyIdentifiableValue)
  end
end
```
becomes
```ruby
class AlertEvent
  include SalsifyAvro::MultitenantValue
  include SalsifyAvro::UniquelyIdentifiableValue
end
```
@cgrdavies - you're prime
/cc @tjwp @jkapell 