### PR TITLE
README Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,17 @@
 # avromatic changelog
 
 ## v2.0.0 (unreleased)
-- Remove Virtus dependency.
-- Raise `Avromatic::Model::CoercionError` when attribute values can't be coerced to the target type.
+- Remove [virtus](https://github.com/solnic/virtus) dependency resulting in a 3x performance improvement in model instantation and 1.4x - 2.0x improvement in Avro serialization and Avromatic code simplification.
+- Raise `Avromatic::Model::CoercionError` when attribute values can't be coerced to the target type in model constructors and attribute setters. Previously coercion errors weren't detected until Avro serialization or an explicit call to `valid?`.
 - Prevent model instances from being constructed with unknown attributes by default. This can be disabled
-  by setting `Avromatic.allow_unknown_attributes` to `false`.
+  by setting `Avromatic.allow_unknown_attributes` to `false`. Previously unknown attributes were ignored.
 - Validate required attributes are present when serializing to Avro for better error messages. Explicit 
   validation can still be done by calling the `valid?` or `invalid?` methods from the 
   [ActiveModel::Validations](https://edgeapi.rubyonrails.org/classes/ActiveModel/Validations.html) interface
   but errors will now appear under the `:base` key.  
 - Support for custom types in unions with more than one non-null type.
 - Drop support for Ruby < 2.3 and Rails < 5.0.
-- Call `super()` in model constructor.
+- Call `super()` in model constructor making it easier to define class/module hierarchies for models.
 
 ## v1.0.0
 - No changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@
 ## v2.0.0 (unreleased)
 - Remove [virtus](https://github.com/solnic/virtus) dependency resulting in a 3x performance improvement in model instantation and 1.4x - 2.0x performance improvement in Avro serialization and Avromatic code simplification.
 - Raise `Avromatic::Model::CoercionError` when attribute values can't be coerced to the target type in model constructors and attribute setters. Previously coercion errors weren't detected until Avro serialization or an explicit call to `valid?`.
-- Prevent model instances from being constructed with unknown attributes by default. This can be disabled
-  by setting `Avromatic.allow_unknown_attributes` to `false`. Previously unknown attributes were ignored.
+- Prevent model instances from being constructed with unknown attributes. Previously unknown attributes were ignored. 
+  This can be disabled by setting `Avromatic.allow_unknown_attributes` to `true`.
+  WARNING: Setting `Avromatic.allow_unknown_attributes` to `true` will result in incorrect union member coercions 
+  if an earlier union member is satisfied by a subset of the latter union member's attributes.
 - Validate required attributes are present when serializing to Avro for better error messages. Explicit 
   validation can still be done by calling the `valid?` or `invalid?` methods from the 
   [ActiveModel::Validations](https://edgeapi.rubyonrails.org/classes/ActiveModel/Validations.html) interface
-  but errors will now appear under the `:base` key. Previously these errors were detected during late in the Avro serialization process resulting in hard to understand error messages. 
+  but errors will now appear under the `:base` key. Previously these errors were detected late in the Avro serialization process resulting in hard to understand error messages. 
 - Support for custom types in unions with more than one non-null type.
 - Drop support for Ruby < 2.3 and Rails < 5.0.
 - Call `super()` in model constructor making it easier to define class/module hierarchies for models.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # avromatic changelog
 
 ## v2.0.0 (unreleased)
-- Remove [virtus](https://github.com/solnic/virtus) dependency resulting in a 3x performance improvement in model instantation and 1.4x - 2.0x improvement in Avro serialization and Avromatic code simplification.
+- Remove [virtus](https://github.com/solnic/virtus) dependency resulting in a 3x performance improvement in model instantation and 1.4x - 2.0x performance improvement in Avro serialization and Avromatic code simplification.
 - Raise `Avromatic::Model::CoercionError` when attribute values can't be coerced to the target type in model constructors and attribute setters. Previously coercion errors weren't detected until Avro serialization or an explicit call to `valid?`.
 - Prevent model instances from being constructed with unknown attributes by default. This can be disabled
   by setting `Avromatic.allow_unknown_attributes` to `false`. Previously unknown attributes were ignored.
 - Validate required attributes are present when serializing to Avro for better error messages. Explicit 
   validation can still be done by calling the `valid?` or `invalid?` methods from the 
   [ActiveModel::Validations](https://edgeapi.rubyonrails.org/classes/ActiveModel/Validations.html) interface
-  but errors will now appear under the `:base` key.  
+  but errors will now appear under the `:base` key. Previously these errors were detected during late in the Avro serialization process resulting in hard to understand error messages. 
 - Support for custom types in unions with more than one non-null type.
 - Drop support for Ruby < 2.3 and Rails < 5.0.
 - Call `super()` in model constructor making it easier to define class/module hierarchies for models.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ Avromatic with unreleased Avro features.
   option is useful for defining models that will be extended when the load order
   is important.
 * **allow_unknown_attributes**: Optionally allow model constructors to silently
-  ignore unknown attributes. Defaults to `false`.
+  ignore unknown attributes. Defaults to `false`. WARNING: Setting this to `true` 
+  will result in incorrect union member coercions if an earlier union member is 
+  satisfied by a subset of the latter union member's attributes.
 
 #### Custom Types
 

--- a/README.md
+++ b/README.md
@@ -434,13 +434,6 @@ Requiring this file configures a RSpec before hook that directs any schema
 registry requests to a fake, in-memory schema registry and rebuilds the
 `Avromatic::Messaging` object for each example.
 
-## Upgrading to 2.0
-
-TODO:
-* Coercion validation in initialize/setters
-* Unknown attributes not allowed 
-* Required field validation when serializing to Avro
-
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.


### PR DESCRIPTION
This beefs up the CHANGELOG a bit and removes the `Upgrading to 2.0` section from the README since the necessary content is covered in the CHANGELOG.