### PR TITLE
Fix sporadic logical timestamp test failures

### DIFF
--- a/lib/avromatic/model/types/abstract_timestamp_type.rb
+++ b/lib/avromatic/model/types/abstract_timestamp_type.rb
@@ -24,8 +24,11 @@ module Avromatic
           input.nil? || input.is_a?(::Time) || input.is_a?(::DateTime)
         end
 
-        def coerced?(_value)
-          raise "#{__method__} must be overridden by #{self.class.name}"
+        def coerced?(value)
+          # ActiveSupport::TimeWithZone overrides is_a? is to make it look like a Time
+          # even though it's not which can lead to unexpected behavior if we don't force
+          # a coercion
+          value.is_a?(::Time) && value.class != ActiveSupport::TimeWithZone && truncated?(value)
         end
 
         def serialize(value, **)
@@ -33,6 +36,10 @@ module Avromatic
         end
 
         private
+
+        def truncated?(_value)
+          raise "#{__method__} must be overridden by #{self.class.name}"
+        end
 
         def coerce_time(_input)
           raise "#{__method__} must be overridden by #{self.class.name}"

--- a/lib/avromatic/model/types/timestamp_micros_type.rb
+++ b/lib/avromatic/model/types/timestamp_micros_type.rb
@@ -13,11 +13,11 @@ module Avromatic
           'timestamp-micros'
         end
 
-        def coerced?(value)
-          value.is_a?(::Time) && value.class != ActiveSupport::TimeWithZone && value.nsec % 1000 == 0
-        end
-
         private
+
+        def truncated?(value)
+          value.nsec % 1000 == 0
+        end
 
         def coerce_time(input)
           # value is coerced to a local Time

--- a/lib/avromatic/model/types/timestamp_micros_type.rb
+++ b/lib/avromatic/model/types/timestamp_micros_type.rb
@@ -14,7 +14,7 @@ module Avromatic
         end
 
         def coerced?(value)
-          value.is_a?(::Time) && value.nsec % 1000 == 0
+          value.is_a?(::Time) && value.class != ActiveSupport::TimeWithZone && value.nsec % 1000 == 0
         end
 
         private

--- a/lib/avromatic/model/types/timestamp_millis_type.rb
+++ b/lib/avromatic/model/types/timestamp_millis_type.rb
@@ -13,11 +13,11 @@ module Avromatic
           'timestamp-millis'
         end
 
-        def coerced?(value)
-          value.is_a?(::Time) && value.class != ActiveSupport::TimeWithZone && value.usec % 1000 == 0
-        end
-
         private
+
+        def truncated?(value)
+          value.usec % 1000 == 0
+        end
 
         def coerce_time(input)
           # value is coerced to a local Time

--- a/lib/avromatic/model/types/timestamp_millis_type.rb
+++ b/lib/avromatic/model/types/timestamp_millis_type.rb
@@ -14,7 +14,7 @@ module Avromatic
         end
 
         def coerced?(value)
-          value.is_a?(::Time) && value.usec % 1000 == 0
+          value.is_a?(::Time) && value.class != ActiveSupport::TimeWithZone && value.usec % 1000 == 0
         end
 
         private

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -270,10 +270,12 @@ describe Avromatic::Model::Builder do
           expect(instance.ts_msec).to eq(::Time.at(time.to_i, time.usec / 1000 * 1000))
         end
 
-        it "coerces an ActiveSupport::TimeWithZone" do
-          time = Time.zone.now
-          instance = test_class.new(ts_msec: time)
-          expect(instance.ts_msec).to eq(::Time.at(time.to_i, time.usec / 1000 * 1000))
+        it "coerces an ActiveSupport::TimeWithZone", focus: true do
+          1_000_000.times do
+            time = Time.zone.now
+            instance = test_class.new(ts_msec: time)
+            expect(instance.ts_msec).to eq(::Time.at(time.to_i, time.usec / 1000 * 1000))
+          end
         end
 
         it "raises an Avromatic::Model::CoercionError when the value is a Date" do

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -270,7 +270,7 @@ describe Avromatic::Model::Builder do
           expect(instance.ts_msec).to eq(::Time.at(time.to_i, time.usec / 1000 * 1000))
         end
 
-        it "coerces an ActiveSupport::TimeWithZone", focus: true do
+        it "coerces an ActiveSupport::TimeWithZone", focus: true do # rubocop:disable RSpec/Focus
           1_000_000.times do
             time = Time.zone.now
             instance = test_class.new(ts_msec: time)
@@ -296,10 +296,12 @@ describe Avromatic::Model::Builder do
           expect(instance.ts_usec).to eq(::Time.at(time.to_i, time.usec))
         end
 
-        it "coerces an ActiveSupport::TimeWithZone" do
-          time = Time.zone.now
-          instance = test_class.new(ts_usec: time)
-          expect(instance.ts_usec).to eq(::Time.at(time.to_i, time.usec))
+        it "coerces an ActiveSupport::TimeWithZone", focus: true do # rubocop:disable RSpec/Focus
+          1_000_000.times do
+            time = Time.zone.now
+            instance = test_class.new(ts_usec: time)
+            expect(instance.ts_usec).to eq(::Time.at(time.to_i, time.usec))
+          end
         end
 
         it "raises an Avromatic::Model::CoercionError when the value is a Date" do

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -271,7 +271,6 @@ describe Avromatic::Model::Builder do
         end
 
         it "coerces an ActiveSupport::TimeWithZone" do
-          Time.zone = 'GMT'
           time = Time.zone.now
           instance = test_class.new(ts_msec: time)
           expect(instance.ts_msec).to eq(::Time.at(time.to_i, time.usec / 1000 * 1000))
@@ -296,7 +295,6 @@ describe Avromatic::Model::Builder do
         end
 
         it "coerces an ActiveSupport::TimeWithZone" do
-          Time.zone = 'GMT'
           time = Time.zone.now
           instance = test_class.new(ts_usec: time)
           expect(instance.ts_usec).to eq(::Time.at(time.to_i, time.usec))

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -270,12 +270,11 @@ describe Avromatic::Model::Builder do
           expect(instance.ts_msec).to eq(::Time.at(time.to_i, time.usec / 1000 * 1000))
         end
 
-        it "coerces an ActiveSupport::TimeWithZone", focus: true do # rubocop:disable RSpec/Focus
-          1_000_000.times do
-            time = Time.zone.now
-            instance = test_class.new(ts_msec: time)
-            expect(instance.ts_msec).to eq(::Time.at(time.to_i, time.usec / 1000 * 1000))
-          end
+        it "coerces an ActiveSupport::TimeWithZone" do
+          Time.zone = 'GMT'
+          time = Time.zone.now
+          instance = test_class.new(ts_msec: time)
+          expect(instance.ts_msec).to eq(::Time.at(time.to_i, time.usec / 1000 * 1000))
         end
 
         it "raises an Avromatic::Model::CoercionError when the value is a Date" do
@@ -296,12 +295,11 @@ describe Avromatic::Model::Builder do
           expect(instance.ts_usec).to eq(::Time.at(time.to_i, time.usec))
         end
 
-        it "coerces an ActiveSupport::TimeWithZone", focus: true do # rubocop:disable RSpec/Focus
-          1_000_000.times do
-            time = Time.zone.now
-            instance = test_class.new(ts_usec: time)
-            expect(instance.ts_usec).to eq(::Time.at(time.to_i, time.usec))
-          end
+        it "coerces an ActiveSupport::TimeWithZone" do
+          Time.zone = 'GMT'
+          time = Time.zone.now
+          instance = test_class.new(ts_usec: time)
+          expect(instance.ts_usec).to eq(::Time.at(time.to_i, time.usec))
         end
 
         it "raises an Avromatic::Model::CoercionError when the value is a Date" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,8 @@ RSpec.configure do |config|
     Avromatic.schema_store = AvroTurf::SchemaStore.new(path: 'spec/avro/schema')
     Avromatic.custom_type_registry.clear
     Avromatic.nested_models = Avromatic::ModelRegistry.new
+
+    Time.zone = 'GMT'
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require 'simplecov'
 
 SimpleCov.start do
   add_filter 'spec'
-  minimum_coverage 95
+  # minimum_coverage 95
 end
 
 require 'avro/builder'
@@ -16,6 +16,7 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
   config.extend LogicalTypesHelper
+  config.filter_run focus: true
 
   config.before do
     Avromatic.logger = Logger.new('log/test.log')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require 'simplecov'
 
 SimpleCov.start do
   add_filter 'spec'
-  # minimum_coverage 95
+  minimum_coverage 95
 end
 
 require 'avro/builder'
@@ -16,7 +16,6 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
   config.extend LogicalTypesHelper
-  config.filter_run focus: true
 
   config.before do
     Avromatic.logger = Logger.new('log/test.log')


### PR DESCRIPTION
This PR fixes sporadic logical timestamp test failures like [this](https://travis-ci.org/salsify/avromatic/jobs/440805947) one. The problem was that [ActiveSupport::TimeWithZone](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/time_with_zone.rb#L479) overrides `is_a?` to make it look like a `Time` so the coercion algorithm wouldn't kick in if the test ran at time that happened to be on a millisecond boundary. This would lead to a test failure because `==` would return false for the actual `ActiveSupport::TimeWithZone` vs. the expected `Time`.