### PR TITLE
Define <attribute>? readers for booleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,26 @@ The Avro schema can be specified by name and loaded using the schema store:
 class MyModel
   include Avromatic::Model.build(schema_name :my_model)
 end
+
+# Construct instances by passing in a hash of attributes
+instance = MyModel.new(id: 123, name: 'Tesla Model 3', enabled: true)
+
+# Access attribute values with readers
+instance.name # => "Tesla Model 3"
+
+# Models are immutable by default
+instance.name = 'Tesla Model X' # => NoMethodError (private method `name=' called for #<MyModel:0x00007ff711e64e60>) 
+
+# Booleans can also be accessed by '?' readers that coerce nil to false
+instance.enabled? # => true
+
+# Models implement ===, eql? and hash
+instance == MyModel.new(id: 123, name: 'Tesla Model 3', enabled: true) # => true
+instance.eql?(MyModel.new(id: 123, name: 'Tesla Model 3', enabled: true)) # => true
+instance.hash # => -1279155042741869898
+
+# Retrieve a hash of the model's attributes via to_h, to_hash or attributes
+instance .to_h # => {:id=>123, :name=>"Tesla Model 3", :enabled=>true}
 ```
 
 Or an `Avro::Schema` object can be specified directly:

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -148,6 +148,7 @@ module Avromatic
             attribute_definitions[symbolized_field_name] = attribute_definition
 
             define_method(field.name) { _attributes[symbolized_field_name] }
+            define_method("#{field.name}?") { !!_attributes[symbolized_field_name] } if boolean?(field)
 
             define_method("#{field.name}=") do |value|
               _attributes[symbolized_field_name] = attribute_definitions[symbolized_field_name].coerce(value)
@@ -159,6 +160,11 @@ module Avromatic
               define_method(:dup) { self }
             end
           end
+        end
+
+        def boolean?(field)
+          field.type.type_sym == :boolean ||
+            (FieldHelper.optional?(field) && field.type.schemas.last.type_sym == :boolean)
         end
 
         def create_type(field)

--- a/spec/avro/dsl/test/optional_boolean.rb
+++ b/spec/avro/dsl/test/optional_boolean.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+namespace :test
+
+record :optional_boolean do
+  optional :b, :boolean
+end

--- a/spec/avro/schema/test/optional_boolean.avsc
+++ b/spec/avro/schema/test/optional_boolean.avsc
@@ -1,0 +1,15 @@
+{
+  "type": "record",
+  "name": "optional_boolean",
+  "namespace": "test",
+  "fields": [
+    {
+      "name": "b",
+      "type": [
+        "null",
+        "boolean"
+      ],
+      "default": null
+    }
+  ]
+}

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -77,6 +77,30 @@ describe Avromatic::Model::Builder do
       let(:schema_name) { 'test.primitive_types' }
 
       it_behaves_like "a generated model"
+
+      it "defines a boolean accessor that returns false for a false value" do
+        instance = test_class.new(tf: false)
+        expect(instance.tf?).to eq(false)
+      end
+
+      it "defines a boolean accessor that returns true for a true value" do
+        instance = test_class.new(tf: true)
+        expect(instance.tf?).to eq(true)
+      end
+
+      it "defines a boolean accessor that returns false for a null value" do
+        instance = test_class.new(tf: nil)
+        expect(instance.tf?).to eq(false)
+      end
+
+      context "with an optional boolean" do
+        let(:schema_name) { 'test.optional_boolean' }
+
+        it "defines a boolean accessor" do
+          instance = test_class.new(b: true)
+          expect(instance.b?).to eq(true)
+        end
+      end
     end
 
     context "with a schema" do


### PR DESCRIPTION
This defines readers with the `?` suffix for boolean fields.