### PR TITLE
Improve type coercion errors

### DIFF
--- a/lib/avromatic/model.rb
+++ b/lib/avromatic/model.rb
@@ -5,6 +5,7 @@ require 'avromatic/model/coercion_error'
 require 'avromatic/model/message_decoder'
 require 'avromatic/model/custom_type_registry'
 require 'avromatic/model/validation_error'
+require 'avromatic/model/unknown_attribute_error'
 
 module Avromatic
   module Model

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -53,6 +53,9 @@ module Avromatic
             raise Avromatic::Model::CoercionError.new("Value for #{owner.name}##{name} could not be coerced to a #{type.name} " \
               "because a #{input.class.name} was provided but expected a #{type.input_classes.map(&:name).to_sentence(two_words_connector: ' or ', last_word_connector: ', or ')}. " \
               "Provided argument: #{input.inspect}")
+          elsif input.is_a?(Hash) && type.is_a?(Avromatic::Model::Types::UnionType)
+            raise Avromatic::Model::CoercionError.new("Value for #{owner.name}##{name} could not be coerced to a #{type.name} " \
+              "because no union member type has all of the provided attributes: #{input.inspect}")
           else
             raise Avromatic::Model::CoercionError.new("Value for #{owner.name}##{name} could not be coerced to a #{type.name}. " \
               "Provided argument: #{input.inspect}")

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -51,7 +51,7 @@ module Avromatic
         rescue StandardError
           if type.input_classes && type.input_classes.none? { |input_class| input.is_a?(input_class) }
             raise Avromatic::Model::CoercionError.new("Value for #{owner.name}##{name} could not be coerced to a #{type.name} " \
-              "because a #{input.class.name} was provided but expected one of #{type.input_classes.map(&:name).to_sentence(two_words_connector: ' or ', last_word_connector: ', or ')}. " \
+              "because a #{input.class.name} was provided but expected a #{type.input_classes.map(&:name).to_sentence(two_words_connector: ' or ', last_word_connector: ', or ')}. " \
               "Provided argument: #{input.inspect}")
           else
             raise Avromatic::Model::CoercionError.new("Value for #{owner.name}##{name} could not be coerced to a #{type.name}. " \

--- a/lib/avromatic/model/types/abstract_timestamp_type.rb
+++ b/lib/avromatic/model/types/abstract_timestamp_type.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_support/time_with_zone'
+
 module Avromatic
   module Model
     module Types

--- a/lib/avromatic/model/types/abstract_timestamp_type.rb
+++ b/lib/avromatic/model/types/abstract_timestamp_type.rb
@@ -3,11 +3,16 @@
 module Avromatic
   module Model
     module Types
-      class AbstractTimestampType
+      class AbstractTimestampType < AbstractType
         VALUE_CLASSES = [::Time].freeze
+        INPUT_CLASSES = [::Time, ::DateTime, ::ActiveSupport::TimeWithZone].freeze
 
         def value_classes
           VALUE_CLASSES
+        end
+
+        def input_classes
+          INPUT_CLASSES
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/abstract_type.rb
+++ b/lib/avromatic/model/types/abstract_type.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Avromatic
+  module Model
+    module Types
+      class AbstractType
+        def value_classes
+          raise "#{__method__} must be overridden by #{self.class.name}"
+        end
+
+        def input_classes
+          value_classes
+        end
+
+        def name
+          raise "#{__method__} must be overridden by #{self.class.name}"
+        end
+
+        def coerce(_input)
+          raise "#{__method__} must be overridden by #{self.class.name}"
+        end
+
+        def coercible?(_input)
+          raise "#{__method__} must be overridden by #{self.class.name}"
+        end
+
+        def coerced?(_value)
+          raise "#{__method__} must be overridden by #{self.class.name}"
+        end
+
+        def serialize(_value, **)
+          raise "#{__method__} must be overridden by #{self.class.name}"
+        end
+      end
+    end
+  end
+end

--- a/lib/avromatic/model/types/array_type.rb
+++ b/lib/avromatic/model/types/array_type.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
+require 'avromatic/model/types/abstract_type'
+
 module Avromatic
   module Model
     module Types
-      class ArrayType
+      class ArrayType < AbstractType
         VALUE_CLASSES = [::Array].freeze
+
         attr_reader :value_type
 
         def initialize(value_type:)

--- a/lib/avromatic/model/types/boolean_type.rb
+++ b/lib/avromatic/model/types/boolean_type.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require 'avromatic/model/types/abstract_type'
+
 module Avromatic
   module Model
     module Types
-      class BooleanType
+      class BooleanType < AbstractType
         VALUE_CLASSES = [::TrueClass, ::FalseClass].freeze
 
         def value_classes

--- a/lib/avromatic/model/types/custom_type.rb
+++ b/lib/avromatic/model/types/custom_type.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require 'avromatic/model/types/abstract_type'
+
 module Avromatic
   module Model
     module Types
-      class CustomType
+      class CustomType < AbstractType
         IDENTITY_PROC = Proc.new { |value| value }
 
         attr_reader :custom_type_configuration, :value_classes, :default_type
@@ -20,6 +22,10 @@ module Avromatic
                            end
         end
 
+        def input_classes
+          # We don't know the valid input classes for a custom type
+        end
+
         def name
           custom_type_configuration.value_class ? custom_type_configuration.value_class.name.to_s.freeze : default_type.name
         end
@@ -31,6 +37,7 @@ module Avromatic
             @deserializer.call(input)
           end
         rescue StandardError => e
+          # TODO: Don't swallow this
           raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}: #{e.message}")
         end
 

--- a/lib/avromatic/model/types/date_type.rb
+++ b/lib/avromatic/model/types/date_type.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require 'avromatic/model/types/abstract_type'
+
 module Avromatic
   module Model
     module Types
-      class DateType
+      class DateType < AbstractType
         VALUE_CLASSES = [::Date].freeze
 
         def value_classes

--- a/lib/avromatic/model/types/enum_type.rb
+++ b/lib/avromatic/model/types/enum_type.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
+require 'avromatic/model/types/abstract_type'
+
 module Avromatic
   module Model
     module Types
-      class EnumType
+      class EnumType < AbstractType
         VALUE_CLASSES = [::String].freeze
+        INPUT_CLASSES = [::String, ::Symbol].freeze
 
         attr_reader :allowed_values
 
@@ -18,6 +21,10 @@ module Avromatic
 
         def value_classes
           VALUE_CLASSES
+        end
+
+        def input_classes
+          INPUT_CLASSES
         end
 
         def coerce(input)

--- a/lib/avromatic/model/types/fixed_type.rb
+++ b/lib/avromatic/model/types/fixed_type.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require 'avromatic/model/types/abstract_type'
+
 module Avromatic
   module Model
     module Types
-      class FixedType
+      class FixedType < AbstractType
         VALUE_CLASSES = [::String].freeze
 
         attr_reader :size

--- a/lib/avromatic/model/types/float_type.rb
+++ b/lib/avromatic/model/types/float_type.rb
@@ -1,13 +1,20 @@
 # frozen_string_literal: true
 
+require 'avromatic/model/types/abstract_type'
+
 module Avromatic
   module Model
     module Types
-      class FloatType
+      class FloatType < AbstractType
         VALUE_CLASSES = [::Float].freeze
+        INPUT_CLASSES = [::Float, ::Integer].freeze
 
         def value_classes
           VALUE_CLASSES
+        end
+
+        def input_classes
+          INPUT_CLASSES
         end
 
         def name

--- a/lib/avromatic/model/types/integer_type.rb
+++ b/lib/avromatic/model/types/integer_type.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require 'avromatic/model/types/abstract_type'
+
 module Avromatic
   module Model
     module Types
-      class IntegerType
+      class IntegerType < AbstractType
         VALUE_CLASSES = [::Integer].freeze
 
         def value_classes

--- a/lib/avromatic/model/types/map_type.rb
+++ b/lib/avromatic/model/types/map_type.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require 'avromatic/model/types/abstract_type'
+
 module Avromatic
   module Model
     module Types
-      class MapType
+      class MapType < AbstractType
         VALUE_CLASSES = [::Hash].freeze
 
         attr_reader :value_type, :key_type

--- a/lib/avromatic/model/types/null_type.rb
+++ b/lib/avromatic/model/types/null_type.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require 'avromatic/model/types/abstract_type'
+
 module Avromatic
   module Model
     module Types
-      class NullType
+      class NullType < AbstractType
         VALUE_CLASSES = [::NilClass].freeze
 
         def value_classes

--- a/lib/avromatic/model/types/record_type.rb
+++ b/lib/avromatic/model/types/record_type.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
+require 'avromatic/model/types/abstract_type'
+
 module Avromatic
   module Model
     module Types
-      class RecordType
-        attr_reader :record_class, :value_classes
+      class RecordType < AbstractType
+        attr_reader :record_class, :value_classes, :input_classes
 
         def initialize(record_class:)
           @record_class = record_class
           @value_classes = [record_class].freeze
+          @input_classes = [record_class, Hash].freeze
         end
 
         def name

--- a/lib/avromatic/model/types/string_type.rb
+++ b/lib/avromatic/model/types/string_type.rb
@@ -1,13 +1,20 @@
 # frozen_string_literal: true
 
+require 'avromatic/model/types/abstract_type'
+
 module Avromatic
   module Model
     module Types
       class StringType
         VALUE_CLASSES = [::String].freeze
+        INPUT_CLASSES = [::String, ::Symbol].freeze
 
         def value_classes
           VALUE_CLASSES
+        end
+
+        def input_classes
+          INPUT_CLASSES
         end
 
         def name

--- a/lib/avromatic/model/types/union_type.rb
+++ b/lib/avromatic/model/types/union_type.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
 require 'avromatic/io'
+require 'avromatic/model/types/abstract_type'
 
 module Avromatic
   module Model
     module Types
-      class UnionType
+      class UnionType < AbstractType
         MEMBER_INDEX = ::Avromatic::IO::DatumReader::UNION_MEMBER_INDEX
-        attr_reader :member_types, :value_classes
+        attr_reader :member_types, :value_classes, :input_classes
 
         def initialize(member_types:)
           @member_types = member_types
           @value_classes = member_types.flat_map(&:value_classes)
+          @input_classes = member_types.flat_map(&:input_classes).uniq
         end
 
         def name

--- a/lib/avromatic/model/unknown_attribute_error.rb
+++ b/lib/avromatic/model/unknown_attribute_error.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Avromatic
+  module Model
+    class UnknownAttributeError < StandardError
+      attr_reader :attributes
+
+      def initialize(message, attributes)
+        super(message)
+        @attributes = attributes
+      end
+    end
+  end
+end

--- a/lib/avromatic/model/unknown_attribute_error.rb
+++ b/lib/avromatic/model/unknown_attribute_error.rb
@@ -3,11 +3,12 @@
 module Avromatic
   module Model
     class UnknownAttributeError < StandardError
-      attr_reader :attributes
+      attr_reader :unknown_attributes, :allowed_attributes
 
-      def initialize(message, attributes)
+      def initialize(message, unknown_attributes:, allowed_attributes:)
         super(message)
-        @attributes = attributes
+        @unknown_attributes = unknown_attributes
+        @allowed_attributes = allowed_attributes
       end
     end
   end

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -387,7 +387,10 @@ describe Avromatic::Model::Builder do
       input = { unknown: true }
       expect do
         test_class.new(input)
-      end.to raise_error(Avromatic::Model::UnknownAttributeError, "Unexpected arguments for PrimitiveType#initialize: unknown. Provided arguments: #{input.inspect}")
+      end.to raise_error(Avromatic::Model::UnknownAttributeError,
+                         'Unexpected arguments for PrimitiveType#initialize: unknown. ' \
+                          "Only the following arguments are allowed: #{test_class.attribute_definitions.keys.map(&:to_s).sort.join(', ')}. " \
+                          "Provided arguments: #{input.inspect}")
     end
 
     it "does not raise an Avromatic::Model::UnknownAttributeError when passed an unknown attribute when allow_unknown_attributes is true" do
@@ -675,8 +678,8 @@ describe Avromatic::Model::Builder do
           test_class.new(sub: sub_input)
         end.to raise_error(Avromatic::Model::CoercionError,
                            'Value for NestedRecord#sub could not be coerced to a NestedRecordSubRecord ' \
-                           'because a String was provided but expected a NestedRecordSubRecord or Hash. ' \
-                           "Provided argument: #{sub_input.inspect}")
+                             'because a String was provided but expected a NestedRecordSubRecord or Hash. ' \
+                             "Provided argument: #{sub_input.inspect}")
       end
 
       it "does not coerce hashes with additional attributes" do
@@ -685,7 +688,8 @@ describe Avromatic::Model::Builder do
           test_class.new(sub: sub_input)
         end.to raise_error(Avromatic::Model::CoercionError,
                            'Value for NestedRecord#sub could not be coerced to a NestedRecordSubRecord because the ' \
-                           "following unexpected attributes were provided: b. Provided argument: #{sub_input.inspect}")
+                             'following unexpected attributes were provided: b. Only the following attributes are allowed: i, str. ' \
+                             "Provided argument: #{sub_input.inspect}")
       end
     end
 

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -675,7 +675,7 @@ describe Avromatic::Model::Builder do
           test_class.new(sub: sub_input)
         end.to raise_error(Avromatic::Model::CoercionError,
                            'Value for NestedRecord#sub could not be coerced to a NestedRecordSubRecord ' \
-                           'because a String was provided but expected one of NestedRecordSubRecord or Hash. ' \
+                           'because a String was provided but expected a NestedRecordSubRecord or Hash. ' \
                            "Provided argument: #{sub_input.inspect}")
       end
 

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -832,6 +832,15 @@ describe Avromatic::Model::Builder do
         expect(test_class.new(value1).message.foo_message).to eq('foo')
         expect(test_class.new(value2).message.bar_message).to eq('bar')
       end
+
+      it "does not coerce hashes with keys that don't match a union member's type" do
+        message_input = { foo_message: 'foo', bar_message: 'bar' }
+        expect do
+          test_class.new(header: 'B', message: message_input)
+        end.to raise_error(Avromatic::Model::CoercionError,
+                           'Value for RealUnion#message could not be coerced to a union[Foo, Bar] ' \
+                              "because no union member type has all of the provided attributes: #{message_input.inspect}")
+      end
     end
 
     context "union of records with overlapping fields" do


### PR DESCRIPTION
This PR improves type coercion errors by providing more details on the cause of the error. The test changes are the easiest way to see the updated error messages. It also fixes a bug that caused the unknown attribute detection code to generate an incorrect message for string attribute keys.

@skarger - you're prime 