### PR TITLE
Allow generated model attribute accessors to be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## v2.0.1
+- Allow generated model attribute accessors to be overridden. This was a regression in Avromatic 2.0.0.
+
 ## v2.0.0
 - Remove [virtus](https://github.com/solnic/virtus) dependency resulting in a 3x performance improvement in model instantation and 1.4x - 2.0x performance improvement in Avro serialization and Avromatic code simplification.
 - Raise `Avromatic::Model::CoercionError` when attribute values can't be coerced to the target type in model constructors and attribute setters. Previously coercion errors weren't detected until Avro serialization or an explicit call to `valid?`.

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -21,7 +21,7 @@ module Avromatic
       end
 
       class AttributeDefinition
-        attr_reader :name, :type, :field, :default, :owner
+        attr_reader :name, :setter_name, :type, :field, :default, :owner
         delegate :serialize, to: :type
 
         def initialize(owner:, field:, type:)
@@ -29,6 +29,7 @@ module Avromatic
           @field = field
           @type = type
           @name = field.name.to_sym
+          @setter_name = "#{field.name}=".to_sym
           @default = if field.default == :no_default
                        nil
                      elsif field.default.duplicable?
@@ -77,13 +78,13 @@ module Avromatic
           if data.include?(attribute_name)
             valid_keys << attribute_name
             value = data.fetch(attribute_name)
-            _attributes[attribute_name] = attribute_definition.coerce(value)
+            send(attribute_definition.setter_name, value)
           elsif data.include?(attribute_name.to_s)
             valid_keys << attribute_name
             value = data[attribute_name.to_s]
-            _attributes[attribute_name] = attribute_definition.coerce(value)
+            send(attribute_definition.setter_name, value)
           elsif !attributes.include?(attribute_name)
-            _attributes[attribute_name] = attribute_definition.default
+            send(attribute_definition.setter_name, attribute_definition.default)
           end
         end
 

--- a/lib/avromatic/model/field_helper.rb
+++ b/lib/avromatic/model/field_helper.rb
@@ -15,6 +15,11 @@ module Avromatic
       def required?(field)
         !optional?(field)
       end
+
+      def boolean?(field)
+        field.type.type_sym == :boolean ||
+          (FieldHelper.optional?(field) && field.type.schemas.last.type_sym == :boolean)
+      end
     end
   end
 end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Avromatic
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -7,9 +7,6 @@ describe Avromatic::Model::Builder do
   let(:test_class) do
     described_class.model(schema_name: schema_name)
   end
-  let(:mutable_test_class) do
-    described_class.model(schema_name: schema_name, mutable: true)
-  end
   let(:values) { { s: 'foo', tf: true, i: 42 } }
 
   let(:attribute_names) do
@@ -1158,12 +1155,26 @@ describe Avromatic::Model::Builder do
 
   context "mutable models" do
     let(:schema_name) { 'test.primitive_types' }
+    let(:mutable_test_class) do
+      described_class.model(schema_name: schema_name, mutable: true) do
+        attr_reader :subclass_called
+
+        def s=(*)
+          @subclass_called = true
+          super
+        end
+      end
+    end
     let(:mutable_model) { mutable_test_class.new(s: 'old value') }
 
     it "allows changes to models" do
-      expect do
-        mutable_model.s = 'new value'
-      end.not_to raise_error
+      mutable_model.s = 'new value'
+      expect(mutable_model.s).to eq('new value')
+    end
+
+    it "allows setters to be overridden" do
+      mutable_model.s = 'new value'
+      expect(mutable_model.subclass_called).to eq(true)
     end
   end
 

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -1157,24 +1157,30 @@ describe Avromatic::Model::Builder do
     let(:schema_name) { 'test.primitive_types' }
     let(:mutable_test_class) do
       described_class.model(schema_name: schema_name, mutable: true) do
-        attr_reader :subclass_called
+        attr_reader :subclass_setter_called
 
         def s=(*)
-          @subclass_called = true
+          @subclass_setter_called = true
           super
         end
       end
     end
-    let(:mutable_model) { mutable_test_class.new(s: 'old value') }
 
     it "allows changes to models" do
+      mutable_model = mutable_test_class.new(s: 'old value')
       mutable_model.s = 'new value'
       expect(mutable_model.s).to eq('new value')
     end
 
     it "allows setters to be overridden" do
+      mutable_model = mutable_test_class.new
       mutable_model.s = 'new value'
-      expect(mutable_model.subclass_called).to eq(true)
+      expect(mutable_model.subclass_setter_called).to eq(true)
+    end
+
+    it "invokes setters from the constructor" do
+      mutable_model = mutable_test_class.new(s: 'new_value')
+      expect(mutable_model.subclass_setter_called).to eq(true)
     end
   end
 

--- a/spec/avromatic/model/messaging_serialization_spec.rb
+++ b/spec/avromatic/model/messaging_serialization_spec.rb
@@ -111,14 +111,14 @@ describe Avromatic::Model::MessagingSerialization do
           end
 
           record :with_embedded do
-            required :hash, :map, values: :submodel
+            required :map, :map, values: :submodel
           end
         end
         Avromatic::Model.model(schema: schema)
       end
       let(:values) do
         {
-          hash: {
+          map: {
             foo: { length: 3, str: 'bar' },
             baz: { length: 6, str: 'foobar' }
           }
@@ -132,7 +132,7 @@ describe Avromatic::Model::MessagingSerialization do
       end
 
       it "encodes the value for the model" do
-        first_value = instance.hash['foo']
+        first_value = instance.map['foo']
         expect(first_value.length).to eq(3)
         expect(first_value.str).to eq('bar')
         message_value = instance.avro_message_value


### PR DESCRIPTION
This PR puts all generated model methods into a module so they can be overridden by subclasses (which Avromatic 1.0 supported). 