### PR TITLE
Fix timestamp-millis coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v2.0.1
 - Allow generated model attribute accessors to be overridden. This was a regression in Avromatic 2.0.0.
+- Ensure that timestamp-millis are coerced when the number of microseconds is divisible by 1,000 but the
+  number of nanoseconds is not divisible by 1,000,000.
 
 ## v2.0.0
 - Remove [virtus](https://github.com/solnic/virtus) dependency resulting in a 3x performance improvement in model instantation and 1.4x - 2.0x performance improvement in Avro serialization and Avromatic code simplification.

--- a/lib/avromatic/model/types/timestamp_micros_type.rb
+++ b/lib/avromatic/model/types/timestamp_micros_type.rb
@@ -16,7 +16,7 @@ module Avromatic
         private
 
         def truncated?(value)
-          value.nsec % 1000 == 0
+          value.nsec % 1_000 == 0
         end
 
         def coerce_time(input)

--- a/lib/avromatic/model/types/timestamp_millis_type.rb
+++ b/lib/avromatic/model/types/timestamp_millis_type.rb
@@ -16,7 +16,7 @@ module Avromatic
         private
 
         def truncated?(value)
-          value.usec % 1000 == 0
+          value.nsec % 1_000_000 == 0
         end
 
         def coerce_time(input)

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -1044,13 +1044,10 @@ describe Avromatic::Model::Builder do
           end
         end
 
-        it "coerces a time to a union member", check_me_out: true do
-          10_000_000.times do |i|
-            puts i + 1 if (i + 1) % 1000 == 0
-            now = Time.now
-            instance = test_class.new(u: now)
-            expect(instance.u).to eq(Time.at(now.to_i, now.usec))
-          end
+        it "coerces a time to a union member" do
+          time = Time.at(1540332724, 123456.789)
+          instance = test_class.new(u: time)
+          expect(instance.u).to eq(Time.at(1540332724, 123456))
         end
       end
 
@@ -1063,17 +1060,10 @@ describe Avromatic::Model::Builder do
           end
         end
 
-        it "coerces a time to a union member", check_me_out: true do
-          10_000_000.times do |i|
-            puts i + 1 if (i + 1) % 1000 == 0
-            # now = Time.at(1540332724.4770002)
-            now = Time.now
-            instance = test_class.new(u: now)
-            expected = Time.at(now.to_i, now.usec / 1000 * 1000)
-            unless instance.u == expected
-              raise "Expected #{expected.class.name}(#{expected.inspect}, #{expected.to_f}) but got #{instance.u.class.name}(#{instance.u.inspect}, #{instance.u.to_f})"
-            end
-          end
+        it "coerces a time to a union member" do
+          time = Time.at(1540332724, 123456.789)
+          instance = test_class.new(u: time)
+          expect(instance.u).to eq(Time.at(1540332724, 123_000))
         end
       end
 

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -1063,10 +1063,13 @@ describe Avromatic::Model::Builder do
           end
         end
 
-        it "coerces a time to a union member" do
-          now = Time.now
-          instance = test_class.new(u: now)
-          expect(instance.u).to eq(Time.at(now.to_i, now.usec / 1000 * 1000))
+        it "coerces a time to a union member", check_me_out: true do
+          1_000_000.times do |i|
+            puts i + 1 if (i + 1) % 1000 == 0
+            now = Time.now
+            instance = test_class.new(u: now)
+            expect(instance.u).to eq(Time.at(now.to_i, now.usec / 1000 * 1000))
+          end
         end
       end
 

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -1047,10 +1047,13 @@ describe Avromatic::Model::Builder do
           end
         end
 
-        it "coerces a time to a union member" do
-          now = Time.now
-          instance = test_class.new(u: now)
-          expect(instance.u).to eq(Time.at(now.to_i, now.usec))
+        it "coerces a time to a union member", check_me_out: true do
+          10_000_000.times do |i|
+            puts i + 1 if (i + 1) % 1000 == 0
+            now = Time.now
+            instance = test_class.new(u: now)
+            expect(instance.u).to eq(Time.at(now.to_i, now.usec))
+          end
         end
       end
 
@@ -1064,8 +1067,9 @@ describe Avromatic::Model::Builder do
         end
 
         it "coerces a time to a union member", check_me_out: true do
-          1_000_000.times do |i|
+          10_000_000.times do |i|
             puts i + 1 if (i + 1) % 1000 == 0
+            # now = Time.at(1540332724.4770002)
             now = Time.now
             instance = test_class.new(u: now)
             expected = Time.at(now.to_i, now.usec / 1000 * 1000)

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -311,23 +311,28 @@ describe Avromatic::Model::Builder do
       it_behaves_like "a generated model"
 
       context "timestamp-millis" do
-        it "coerces a Time" do
-          time = Time.now
+        it "coerces a Time to a Time with millisecond precision" do
+          time = Time.at(1540332724, 123456.789)
           instance = test_class.new(ts_msec: time)
-          expect(instance.ts_msec).to eq(::Time.at(time.to_i, time.usec / 1000 * 1000))
+          expect(instance.ts_msec).to eq(::Time.at(1540332724, 123_000))
         end
 
-        it "coerces a DateTime" do
-          time = DateTime.now # rubocop:disable Style/DateTime
+        it "coerces a Time to a Time with millisecond precision even if the number of microseconds is divisible by 1000" do
+          time = Time.at(1540332724, 123_000.789)
           instance = test_class.new(ts_msec: time)
-          expect(instance.ts_msec).to eq(::Time.at(time.to_i, time.usec / 1000 * 1000))
+          expect(instance.ts_msec).to eq(::Time.at(1540332724, 123_000))
         end
 
-        it "coerces an ActiveSupport::TimeWithZone" do
-          Time.zone = 'GMT'
-          time = Time.zone.now
+        it "coerces a DateTime to a Time with millisecond precision" do
+          time = Time.at(1540332724, 123456.789).to_datetime
           instance = test_class.new(ts_msec: time)
-          expect(instance.ts_msec).to eq(::Time.at(time.to_i, time.usec / 1000 * 1000))
+          expect(instance.ts_msec).to eq(::Time.at(1540332724, 123_000))
+        end
+
+        it "coerces an ActiveSupport::TimeWithZone to a Time with millisecond precision" do
+          time = Time.zone.at(1540332724.123456789)
+          instance = test_class.new(ts_msec: time)
+          expect(instance.ts_msec).to eq(::Time.at(1540332724, 123_000))
         end
 
         it "raises an Avromatic::Model::CoercionError when the value is a Date" do
@@ -336,23 +341,22 @@ describe Avromatic::Model::Builder do
       end
 
       context "timestamp-micros" do
-        it "coerces a Time" do
-          time = Time.now
+        it "coerces a Time to a Time with microsecond precision" do
+          time = Time.at(1540332724, 123456.789)
           instance = test_class.new(ts_usec: time)
-          expect(instance.ts_usec).to eq(::Time.at(time.to_i, time.usec))
+          expect(instance.ts_usec).to eq(::Time.at(1540332724, 123456))
         end
 
-        it "coerces a DateTime" do
-          time = DateTime.now # rubocop:disable Style/DateTime
+        it "coerces a DateTime to a Time with microsecond precision" do
+          time = Time.at(1540332724, 123456.789).to_datetime
           instance = test_class.new(ts_usec: time)
-          expect(instance.ts_usec).to eq(::Time.at(time.to_i, time.usec))
+          expect(instance.ts_usec).to eq(::Time.at(1540332724, 123456))
         end
 
-        it "coerces an ActiveSupport::TimeWithZone" do
-          Time.zone = 'GMT'
-          time = Time.zone.now
+        it "coerces an ActiveSupport::TimeWithZone to a Time with microsecond precision" do
+          time = Time.zone.at(1540332724.123456789)
           instance = test_class.new(ts_usec: time)
-          expect(instance.ts_usec).to eq(::Time.at(time.to_i, time.usec))
+          expect(instance.ts_usec).to eq(::Time.at(1540332724, 123456))
         end
 
         it "raises an Avromatic::Model::CoercionError when the value is a Date" do
@@ -1045,9 +1049,9 @@ describe Avromatic::Model::Builder do
         end
 
         it "coerces a time to a union member" do
-          time = Time.at(1540332724, 123456.789)
+          time = Time.at(1540332724)
           instance = test_class.new(u: time)
-          expect(instance.u).to eq(Time.at(1540332724, 123456))
+          expect(instance.u).to eq(Time.at(1540332724))
         end
       end
 
@@ -1061,9 +1065,9 @@ describe Avromatic::Model::Builder do
         end
 
         it "coerces a time to a union member" do
-          time = Time.at(1540332724, 123456.789)
+          time = Time.at(1540332724)
           instance = test_class.new(u: time)
-          expect(instance.u).to eq(Time.at(1540332724, 123_000))
+          expect(instance.u).to eq(Time.at(1540332724))
         end
       end
 

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -1068,7 +1068,10 @@ describe Avromatic::Model::Builder do
             puts i + 1 if (i + 1) % 1000 == 0
             now = Time.now
             instance = test_class.new(u: now)
-            expect(instance.u).to eq(Time.at(now.to_i, now.usec / 1000 * 1000))
+            expected = Time.at(now.to_i, now.usec / 1000 * 1000)
+            unless instance.u == expected
+              raise "Expected #{expected.class.name}(#{expected.inspect}, #{expected.to_f}) but got #{instance.u.class.name}(#{instance.u.inspect}, #{instance.u.to_f})"
+            end
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,8 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 RSpec.configure do |config|
   config.extend LogicalTypesHelper
 
+  config.filter_run check_me_out: true
+
   config.before do
     Avromatic.logger = Logger.new('log/test.log')
     Avromatic.registry_url = 'http://registry.example.com'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,8 +17,6 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 RSpec.configure do |config|
   config.extend LogicalTypesHelper
 
-  config.filter_run check_me_out: true
-
   config.before do
     Avromatic.logger = Logger.new('log/test.log')
     Avromatic.registry_url = 'http://registry.example.com'


### PR DESCRIPTION
This fixes a bug where timestamp-millis where not coerced when the number of microseconds was divisible by 1,000 but the number of nanoseconds was not divisible by 1,000,000.

@skarger - you're prime