### PR TITLE
Reduce string allocations during model initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## v2.0.2
+- Optimize model initialization and decoding
+
 ## v2.0.1
 - Allow generated model attribute accessors to be overridden. This was a regression in Avromatic 2.0.0.
 - Ensure that timestamp-millis are coerced when the number of microseconds is divisible by 1,000 but the

--- a/avromatic.gemspec
+++ b/avromatic.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'ice_nine'
 
   spec.add_development_dependency 'avro-builder', '>= 0.12.0'
-  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'bundler', '>= 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov'

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -29,7 +29,7 @@ module Avromatic
           @field = field
           @type = type
           @name = field.name.to_sym
-          @name_string = field.name.to_s.freeze
+          @name_string = field.name.to_s.dup.freeze
           @setter_name = "#{field.name}=".to_sym
           @default = if field.default == :no_default
                        nil

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -21,7 +21,7 @@ module Avromatic
       end
 
       class AttributeDefinition
-        attr_reader :name, :setter_name, :type, :field, :default, :owner
+        attr_reader :name, :name_string, :setter_name, :type, :field, :default, :owner
         delegate :serialize, to: :type
 
         def initialize(owner:, field:, type:)
@@ -29,6 +29,7 @@ module Avromatic
           @field = field
           @type = type
           @name = field.name.to_sym
+          @name_string = field.name.to_s
           @setter_name = "#{field.name}=".to_sym
           @default = if field.default == :no_default
                        nil
@@ -79,9 +80,9 @@ module Avromatic
             valid_keys << attribute_name
             value = data.fetch(attribute_name)
             send(attribute_definition.setter_name, value)
-          elsif data.include?(attribute_name.to_s)
+          elsif data.include?(attribute_definition.name_string)
             valid_keys << attribute_name
-            value = data[attribute_name.to_s]
+            value = data[attribute_definition.name_string]
             send(attribute_definition.setter_name, value)
           elsif !attributes.include?(attribute_name)
             send(attribute_definition.setter_name, attribute_definition.default)

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -29,7 +29,7 @@ module Avromatic
           @field = field
           @type = type
           @name = field.name.to_sym
-          @name_string = field.name.to_s
+          @name_string = field.name.to_s.freeze
           @setter_name = "#{field.name}=".to_sym
           @default = if field.default == :no_default
                        nil

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Avromatic
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 end


### PR DESCRIPTION
Instead of allocating two strings per attribute, we can cache this on the attribute definition.

Before:
```
Calculating -------------------------------------
                avro   288.272k memsize (     0.000  retained)
                         2.392k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
Warming up --------------------------------------
                avro    40.000  i/100ms
Calculating -------------------------------------
                avro    415.694  (± 5.5%) i/s -      2.080k in   5.019321s
```
After:
```
Calculating -------------------------------------
                avro   259.232k memsize (     0.000  retained)
                         1.666k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
Warming up --------------------------------------
                avro    43.000  i/100ms
Calculating -------------------------------------
                avro    446.097  (± 4.5%) i/s -      2.236k in   5.023264s
```

prime @will89 
cc @jturkel @tjwp