### PR TITLE
Add structured information to UnexpectedKeyError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## v2.1.0
+- Add `key_schema_name` and `value_schema_name` attributes to `UnexpectedKeyError`.
+
 ## v2.0.2
 - Optimize model initialization and decoding
 

--- a/lib/avromatic/model/message_decoder.rb
+++ b/lib/avromatic/model/message_decoder.rb
@@ -9,8 +9,12 @@ module Avromatic
       MAGIC_BYTE = [0].pack('C').freeze
 
       class UnexpectedKeyError < StandardError
-        def initialize(schema_key)
-          super("Unexpected schemas #{schema_key}")
+        attr_reader :key_schema_name, :value_schema_name
+
+        def initialize(key_schema_name, value_schema_name)
+          super("Unexpected schemas #{[key_schema_name, value_schema_name]}")
+          @key_schema_name = key_schema_name
+          @value_schema_name = value_schema_name
         end
       end
 
@@ -84,7 +88,7 @@ module Avromatic
       def extract_decode_args(*args)
         message_key, message_value = extract_key_and_value(*args)
         model_key = model_key_for_message(message_key, message_value)
-        raise UnexpectedKeyError.new(model_key) unless model_map.key?(model_key)
+        raise UnexpectedKeyError.new(*model_key) unless model_map.key?(model_key)
         [model_map[model_key], message_key, message_value]
       end
 

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Avromatic
-  VERSION = '2.0.2'
+  VERSION = '2.1.0'
 end


### PR DESCRIPTION
This PR adds `key_schema_name` and `value_schema_name` attributes to `UnexpectedKeyError` so clients can perform more advanced error handling e.g. only log messages for unknown schemas once per schema/kafka topic.

@rlburkes - you're prime