### PR TITLE
Avoid Allocating Empty Hash as Default Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## v2.2.1
+- Avoid allocating default empty hash in `Avromatic::IO::DatumReader.read_data`
+
 ## v2.2.0
 - Add support for Rails 6.0.
 - Drop support for Ruby < 2.4.

--- a/lib/avromatic/io/datum_reader.rb
+++ b/lib/avromatic/io/datum_reader.rb
@@ -10,7 +10,7 @@ module Avromatic
 
       UNION_MEMBER_INDEX = Avromatic::IO::UNION_MEMBER_INDEX
 
-      def read_data(writers_schema, readers_schema, decoder, initial_record = {})
+      def read_data(writers_schema, readers_schema, decoder, initial_record = nil)
         # schema matching
         unless self.class.match_schemas(writers_schema, readers_schema)
           raise Avro::IO::SchemaMatchException.new(writers_schema, readers_schema)
@@ -52,7 +52,7 @@ module Avromatic
                 when :array;   read_array(writers_schema, readers_schema, decoder)
                 when :map;     read_map(writers_schema, readers_schema, decoder)
                 when :union;   read_union(writers_schema, readers_schema, decoder)
-                when :record, :error, :request; read_record(writers_schema, readers_schema, decoder, initial_record)
+                when :record, :error, :request; read_record(writers_schema, readers_schema, decoder, initial_record || {})
                 else
                   raise Avro::AvroError.new("Cannot read unknown schema type: #{writers_schema.type}")
                 end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Avromatic
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
 end


### PR DESCRIPTION
I recently hit a case where I was decoding over 4k Avromatic models within a single ruby process which caused the memory usage to bloat. After some investigation, I noticed that most of the memory usage was originating from this Avromatic gem and more specifically from `datum_reader.rb:13`. The `initial_record` is only used in one case in the method but the hash will be created for each call to `read_data`. The solution here is to use nil as the default value and only allocate the hash when we hit the intended case.

Test
For this benchmark, I decoded an example Avromatic model with several fields 1000 times with the following results:

##### Using version 2.2.0

1.906k (± 5.8%) i/s -      9.513k in   5.009166s
Total allocated: 78.82 MB (519000 objects)
Allocated by location
40.60 MB /gems/avromatic-2.2.0/lib/avromatic/io/datum_reader.rb:13

##### After Fix

1.965k (± 4.7%) i/s -      9.828k in   5.014109s
Total allocated: 41.47 MB (358000 objects)
 The location mentioned above no longer appears in the memory profiler's report

From the result, we gain a slight speed improvement, but more importantly, we reduce total memory allocated by nearly 50%.

prime @jturkel 