### PR TITLE
Allow for string data time to be coerced 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,98 +1,125 @@
 # avromatic changelog
 
+## pending
+
+- Allow for date time to be a string if it can be parsed
+
 ## v2.2.1
+
 - Avoid allocating default empty hash in `Avromatic::IO::DatumReader.read_data`
 
 ## v2.2.0
+
 - Add support for Rails 6.0.
 - Drop support for Ruby < 2.4.
 
 ## v2.1.0
+
 - Add `key_schema_name` and `value_schema_name` attributes to `UnexpectedKeyError`.
 
 ## v2.0.2
+
 - Optimize model initialization and decoding
 
 ## v2.0.1
+
 - Allow generated model attribute accessors to be overridden. This was a regression in Avromatic 2.0.0.
 - Ensure that timestamp-millis are coerced when the number of microseconds is divisible by 1,000 but the
   number of nanoseconds is not divisible by 1,000,000.
 
 ## v2.0.0
+
 - Remove [virtus](https://github.com/solnic/virtus) dependency resulting in a 3x performance improvement in model instantation and 1.4x - 2.0x performance improvement in Avro serialization and Avromatic code simplification.
 - Raise `Avromatic::Model::CoercionError` when attribute values can't be coerced to the target type in model constructors and attribute setters. Previously coercion errors weren't detected until Avro serialization or an explicit call to `valid?`.
-- Prevent model instances from being constructed with unknown attributes. Previously unknown attributes were ignored. 
+- Prevent model instances from being constructed with unknown attributes. Previously unknown attributes were ignored.
   This can be disabled by setting `Avromatic.allow_unknown_attributes` to `true`.
-  WARNING: Setting `Avromatic.allow_unknown_attributes` to `true` will result in incorrect union member coercions 
+  WARNING: Setting `Avromatic.allow_unknown_attributes` to `true` will result in incorrect union member coercions
   if an earlier union member is satisfied by a subset of the latter union member's attributes.
-- Validate required attributes are present when serializing to Avro for better error messages. Explicit 
-  validation can still be done by calling the `valid?` or `invalid?` methods from the 
+- Validate required attributes are present when serializing to Avro for better error messages. Explicit
+  validation can still be done by calling the `valid?` or `invalid?` methods from the
   [ActiveModel::Validations](https://edgeapi.rubyonrails.org/classes/ActiveModel/Validations.html) interface
-  but errors will now appear under the `:base` key. Previously these errors were detected late in the Avro serialization process resulting in hard to understand error messages. 
+  but errors will now appear under the `:base` key. Previously these errors were detected late in the Avro serialization process resulting in hard to understand error messages.
 - Support for custom types in unions with more than one non-null type.
 - Drop support for Ruby < 2.3 and Rails < 5.0.
 - Call `super()` in model constructor making it easier to define class/module hierarchies for models.
 
 ## v1.0.0
+
 - No changes.
 
 ## v0.33.0
+
 - Fix compatibility with avro-patches v0.4.0.
 
 ## v0.32.0
+
 - Improve partial assignment using a hash for records outside of unions.
 - Prevent invalid types from being assigned to primitives in unions.
 - Add validation that primitive attributes have the expected type.
 
 ## v0.31.0
+
 - Add support for Rails 5.2.
 
 ## v0.30.0
+
 - Add `Avromatic::Model::MessageDecoder#model` method to return the Avromatic
   model class for a message.
 
 ## v0.29.1
+
 - Add `Avromatic.build_messaging!` to `avromatic/rspec`.
 
 ## v0.29.0
+
 - Add new public methods `#avro_key_datum` and `#avro_value_datum` on an
   Avromatic model instance that return the attributes of the model suitable for
   Avro encoding without any customizations.
 
 ## v0.28.1
+
 - Fix a bug that raised an error when encoding a cached model containing optional
-  field(s). With this change, immutable model caching now enabled only when 
+  field(s). With this change, immutable model caching now enabled only when
   `avro-patches` is present.
 
 ## v0.28.0
+
 - Add support for caching avro encodings for immutable models
 
 ## v0.27.0
+
 - Patches avromatic model classes to cache `Virtus::ValueObject::AllowedWriterMethods#allowed_writer_methods`
 - Support Rails 5.1
 
 ## v0.26.0
+
 - Caches result of Avromatic::Model::RawSerialization#value_attributes_for_avro for immutable models
 
 ## v0.25.0
+
 - Disallow optional fields in schemas used for keys by default.
 
 ## v0.24.0
+
 - Add `Avromatic::IO::DatumWriter` to optimize the encoding of Avro unions
   from Avromatic models.
 - Expose the `#key_attributes_for_avro` method on models.
 
 ## v0.23.0
+
 - Add mutable option when defining a model.
 
 ## v0.22.0
+
 - Require `avro_schema_registry_client` v0.3.0 or later to avoid
   using `avro-salsify-fork`.
 
 ## v0.21.1
+
 - Fix a bug in the optimization of optional union decoding.
 
 ## v0.21.0
+
 - Remove monkey-patches for `AvroTurf::ConfluentSchemaRegistry` and
   `FakeConfluentSchemaRegistryServer` and depend on `avro_schema_registry-client`
   instead.
@@ -100,35 +127,44 @@
   `use_schema_fingerprint_lookup`.
 
 ## v0.20.0
+
 - Support schema stores with a `#clear_schemas` method.
 
 ## v0.19.0
+
 - Use a fingerprint based on `avro-resolution_canonical_form`.
 
 ## v0.18.1
+
 - Replace another reference to `avromatic/test/fake_schema_registry_server`.
 
 ## v0.18.0
+
 - Compatibility with `avro_turf` v0.8.0. `avromatic/test/fake_schema_registry_server`
   is now deprecated and will be removed in a future release.
   Use `avromatic/test/fake_confluent_schema_registry_server` instead.
 
 ## v0.17.1
+
 - Correctly namespace Avro errors raised by `Avromatic::IO::DatumReader`.
 
 ## v0.17.0
+
 - Add `.register_schemas!` method to generated models to register the associated
   schemas in a schema registry.
 
 ## v0.16.0
+
 - Add `#lookup_subject_schema` method to `AvroTurf::SchemaRegistry` patch to
   directly support looking up existing schema ids by fingerprint.
 
 ## v0.15.1
+
 - Add `Avromatic.use_cacheable_schema_registration` option to control the lookup
   of existing schema ids by fingerprint.
 
 ## v0.15.0
+
 - Add patch to `AvroTurf::SchemaRegistry` to lookup existing schema ids using
   `GET /subjects/:subject/fingerprints/:fingerprint` from `#register`.
   This endpoint is supported in the avro-schema-registry.
@@ -136,35 +172,43 @@
   fingerprint endpoint.
 
 ## v0.14.0
+
 - Add `Avromatic::Messaging` and `Avromatic::IO::DatumReader` classes to
   optimize the decoding of Avro unions to Avromatic models.
 
 ## v0.13.0
+
 - Add interfaces to deserialize as a hash of attributes instead of a model.
 
 ## v0.12.0
+
 - Clear the schema store, if it supports it, prior to code reloading in Rails
   applications. This allows schema changes to be picked up during code
   reloading.
 
 ## v0.11.2
+
 - Fix for models containing optional array and map fields.
 
 ## v0.11.1
+
 - Another fix for Rails initialization and reloading. Do not clear the nested
   models registry the first time that the `to_prepare` hook is called.
 
 ## v0.11.0
+
 - Replace `Avromatic.on_initialize` proc with `Avromatic.eager_load_models`
   array. The models listed by this configuration are added to the registry
   at the end of `.configure` and prior to code reloading in Rails applications.
   This is a compatibility breaking change.
 
 ## v0.10.0
+
 - Add `Avromatic.on_initialize` proc that is called at the end of `.configure`
   and on code reloading in Rails applications.
 
 ## v0.9.0
+
 - Experimental: Add support for more than one non-null type in a union.
 - Allow nested models to be referenced and reused.
 - Fix the serialization of nested complex types.
@@ -176,46 +220,59 @@
 - Truncate values for timestamps to the precision supported by the logical type.
 
 ## v0.8.0
+
 - Add support for logical types. Currently this requires using the
   `avro-salsify-fork` gem for logical types support with Ruby.
 
 ## v0.7.1
+
 - Raise a more descriptive error when attempting to generate a model for a
   non-record Avro type.
 
 ## v0.7.0
+
 - Add RSpec `FakeSchemaRegistryServer` test helper.
 
 ## v0.6.2
+
 - Remove dependency on `Hash#transform_values` from `ActiveSupport` v4.2.
 
 ## v0.6.1
+
 - Fix serialization of array and map types that contain nested models.
 
 ## v0.6.0
+
 - Require `avro_turf` v0.7.0 or later.
 
 ## v0.5.0
+
 - Rename `Avromatic::Model::Decoder` to `MessageDecoder`.
 - Rename `.deserialize` on generated models to `.avro_message_decode`.
 - Add `#avro_raw_key`, `#avro_raw_value` and `.avro_raw_decode` methods to
   generated models to support encoding and decoding without a schema registry.
 
 ## v0.4.0
+
 - Allow the specification of a custom type, including conversion to/from Avro,
   for named types.
 
 ## v0.3.0
+
 - Remove dependency on the `private_attr` gem.
 
 ## v0.2.0
+
 - Allow a module level schema registry to be configured.
 
 ## v0.1.2
+
 - Do not build an `AvroTurf::Messaging` object for each model class.
 
 ## v0.1.1
+
 - Fix Railtie.
 
 ## v0.1.0
+
 - Initial release

--- a/lib/avromatic/model/types/abstract_timestamp_type.rb
+++ b/lib/avromatic/model/types/abstract_timestamp_type.rb
@@ -7,7 +7,7 @@ module Avromatic
     module Types
       class AbstractTimestampType < AbstractType
         VALUE_CLASSES = [::Time].freeze
-        INPUT_CLASSES = [::Time, ::DateTime, ::ActiveSupport::TimeWithZone].freeze
+        INPUT_CLASSES = [::Time, ::DateTime, ::ActiveSupport::TimeWithZone, String].freeze
 
         def value_classes
           VALUE_CLASSES
@@ -22,6 +22,8 @@ module Avromatic
             input
           elsif input.is_a?(::Time) || input.is_a?(::DateTime)
             coerce_time(input)
+          elsif input.is_a?(String) && date_time = DateTime.parse(input)
+            coerce_time(date_time)
           else
             raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")
           end

--- a/lib/avromatic/model/types/abstract_timestamp_type.rb
+++ b/lib/avromatic/model/types/abstract_timestamp_type.rb
@@ -22,7 +22,7 @@ module Avromatic
             input
           elsif input.is_a?(::Time) || input.is_a?(::DateTime)
             coerce_time(input)
-          elsif input.is_a?(String) && date_time = DateTime.parse(input)
+          elsif input.is_a?(String) && (date_time = Time.parse(input))
             coerce_time(date_time)
           else
             raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -336,7 +336,7 @@ describe Avromatic::Model::Builder do
         end
 
         it "coerces an DateTime string to a time with millisecond precision" do
-          time = "2018-10-24 02:12:04.123456 +0400"
+          time = '2018-10-24 02:12:04.123456 +0400'
           instance = test_class.new(ts_msec: time)
           expect(instance.ts_msec).to eq(::Time.at(1540332724, 123_000))
         end
@@ -366,13 +366,13 @@ describe Avromatic::Model::Builder do
         end
 
         it "coerces an DateTime string to a time with microsecond precision" do
-          time = "2018-10-24 02:12:04.123456 +0400"
+          time = '2018-10-24 02:12:04.123456 +0400'
           instance = test_class.new(ts_msec: time)
           expect(instance.ts_msec).to eq(::Time.at(1540332724, 123000))
         end
 
         it "raises an error with bad time string" do
-          time = "bad time string"
+          time = 'bad time string'
           expect { test_class.new(ts_msec: time) }.to raise_error(
             Avromatic::Model::CoercionError,
             'Value for LogicalType#ts_msec could not be coerced to a timestamp-millis. Provided argument: "bad time string"'

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -341,6 +341,14 @@ describe Avromatic::Model::Builder do
           expect(instance.ts_msec).to eq(::Time.at(1540332724, 123_000))
         end
 
+        it "raises an error with bad time string" do
+          time = 'bad time string'
+          expect { test_class.new(ts_msec: time) }.to raise_error(
+            Avromatic::Model::CoercionError,
+            'Value for LogicalType#ts_msec could not be coerced to a timestamp-millis. Provided argument: "bad time string"'
+          )
+        end
+
         it "raises an Avromatic::Model::CoercionError when the value is a Date" do
           expect { test_class.new(ts_msec: Date.today) }.to raise_error(Avromatic::Model::CoercionError)
         end
@@ -367,15 +375,15 @@ describe Avromatic::Model::Builder do
 
         it "coerces an DateTime string to a time with microsecond precision" do
           time = '2018-10-24 02:12:04.123456 +0400'
-          instance = test_class.new(ts_msec: time)
-          expect(instance.ts_msec).to eq(::Time.at(1540332724, 123000))
+          instance = test_class.new(ts_usec: time)
+          expect(instance.ts_usec).to eq(::Time.at(1540332724, 123456))
         end
 
         it "raises an error with bad time string" do
           time = 'bad time string'
-          expect { test_class.new(ts_msec: time) }.to raise_error(
+          expect { test_class.new(ts_usec: time) }.to raise_error(
             Avromatic::Model::CoercionError,
-            'Value for LogicalType#ts_msec could not be coerced to a timestamp-millis. Provided argument: "bad time string"'
+            'Value for LogicalType#ts_usec could not be coerced to a timestamp-micros. Provided argument: "bad time string"'
           )
         end
 

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -335,6 +335,12 @@ describe Avromatic::Model::Builder do
           expect(instance.ts_msec).to eq(::Time.at(1540332724, 123_000))
         end
 
+        it "coerces an DateTime string to a time with millisecond precision" do
+          time = "2018-10-24 02:12:04.123456 +0400"
+          instance = test_class.new(ts_msec: time)
+          expect(instance.ts_msec).to eq(::Time.at(1540332724, 123_000))
+        end
+
         it "raises an Avromatic::Model::CoercionError when the value is a Date" do
           expect { test_class.new(ts_msec: Date.today) }.to raise_error(Avromatic::Model::CoercionError)
         end
@@ -357,6 +363,20 @@ describe Avromatic::Model::Builder do
           time = Time.zone.at(1540332724.123456789)
           instance = test_class.new(ts_usec: time)
           expect(instance.ts_usec).to eq(::Time.at(1540332724, 123456))
+        end
+
+        it "coerces an DateTime string to a time with microsecond precision" do
+          time = "2018-10-24 02:12:04.123456 +0400"
+          instance = test_class.new(ts_msec: time)
+          expect(instance.ts_msec).to eq(::Time.at(1540332724, 123000))
+        end
+
+        it "raises an error with bad time string" do
+          time = "bad time string"
+          expect { test_class.new(ts_msec: time) }.to raise_error(
+            Avromatic::Model::CoercionError,
+            "Value for LogicalType#ts_msec could not be coerced to a timestamp-millis. Provided argument: \"bad time string\""
+          )
         end
 
         it "raises an Avromatic::Model::CoercionError when the value is a Date" do

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -375,7 +375,7 @@ describe Avromatic::Model::Builder do
           time = "bad time string"
           expect { test_class.new(ts_msec: time) }.to raise_error(
             Avromatic::Model::CoercionError,
-            "Value for LogicalType#ts_msec could not be coerced to a timestamp-millis. Provided argument: \"bad time string\""
+            'Value for LogicalType#ts_msec could not be coerced to a timestamp-millis. Provided argument: "bad time string"'
           )
         end
 


### PR DESCRIPTION
In some cases I am passing datetime as a string to the Model, this allows for coercing the string value if possible