### PR TITLE
Load the nested models of eager loaded models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## v2.2.2
+- Fix missing models in the model registry when in development by loading the nested models of eager loaded models.
+
 ## v2.2.1
 - Avoid allocating default empty hash in `Avromatic::IO::DatumReader.read_data`
 

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -86,7 +86,7 @@ module Avromatic
   end
 
   def self.eager_load_models!
-    @eager_load_model_names&.map(&:constantize)&.each(&:register!)
+    @eager_load_model_names&.each { |model_name| model_name.constantize.register! }
   end
   private_class_method :eager_load_models!
 end

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -77,35 +77,46 @@ module Avromatic
         end
       end
     end
-    eager_load_models!(skip_nested_models: skip_clear)
+    eager_load_models!
   end
 
   def self.eager_load_models=(models)
     @eager_load_model_names = Array(models).map { |model| model.is_a?(Class) ? model.name : model }
   end
 
-  def self.eager_load_models!(skip_nested_models: true)
+  def self.eager_load_models!
     (@eager_load_model_names || []).each do |model_name|
       model = model_name.constantize
-      next if !nested_models.ensure_registered_model(model) || skip_nested_models
+      next if nested_models.registered?(model)
 
-      model.attribute_definitions.each do |_attribute, definition|
-        eager_load_nested_models!(definition.type)
+      nested_models.register(model)
+
+      roots = model.attribute_definitions.values.map(&:type)
+      loop do
+        model = roots.shift
+        eager_load_nested_models!(model, roots)
+
+        break if roots.empty?
       end
+
     end
   end
   private_class_method :eager_load_models!
 
-  def self.eager_load_nested_models!(type)
+  def self.eager_load_nested_models!(type, roots)
     case type
     when Avromatic::Model::Types::ArrayType, Avromatic::Model::Types::MapType
       eager_load_nested_models!(type.value_type)
     when Avromatic::Model::Types::CustomType
-      eager_load_nested_models!(type.default_type) # correct?
+      eager_load_nested_models!(type.default_type)
     when Avromatic::Model::Types::UnionType
       type.member_types.each { |member_type| eager_load_nested_models!(member_type) }
     when Avromatic::Model::Types::RecordType
-      nested_models.ensure_registered_model(type.record_class)
+      model = type.record_class
+      unless nested_models.registered?(model)
+        nested_models.register(model)
+        roots.concat(model.attribute_definitions.values.map(&:type))
+      end
     end
   end
   private_class_method :eager_load_nested_models!

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -77,19 +77,38 @@ module Avromatic
         end
       end
     end
-    eager_load_models!
+    eager_load_models!(skip_nested_models: skip_clear)
   end
 
   def self.eager_load_models=(models)
     @eager_load_model_names = Array(models).map { |model| model.is_a?(Class) ? model.name : model }
   end
 
-  def self.eager_load_models!
+  def self.eager_load_models!(skip_nested_models: true)
     (@eager_load_model_names || []).each do |model_name|
-      nested_models.ensure_registered_model(model_name.constantize)
+      model = model_name.constantize
+      next if !nested_models.ensure_registered_model(model) || skip_nested_models
+
+      model.attribute_definitions.each do |_attribute, definition|
+        eager_load_nested_models!(definition.type)
+      end
     end
   end
   private_class_method :eager_load_models!
+
+  def self.eager_load_nested_models!(type)
+    case type
+    when Avromatic::Model::Types::ArrayType, Avromatic::Model::Types::MapType
+      eager_load_nested_models!(type.value_type)
+    when Avromatic::Model::Types::CustomType
+      eager_load_nested_models!(type.default_type) # correct?
+    when Avromatic::Model::Types::UnionType
+      type.member_types.each { |member_type| eager_load_nested_models!(member_type) }
+    when Avromatic::Model::Types::RecordType
+      nested_models.ensure_registered_model(type.record_class)
+    end
+  end
+  private_class_method :eager_load_nested_models!
 end
 
 require 'avromatic/railtie' if defined?(Rails)

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -8,7 +8,6 @@ require 'avromatic/model'
 require 'avromatic/model_registry'
 require 'avromatic/messaging'
 require 'active_support/core_ext/string/inflections'
-require 'active_support/core_ext/array/wrap'
 require 'avromatic/patches'
 
 module Avromatic
@@ -82,7 +81,7 @@ module Avromatic
   end
 
   def self.eager_load_models=(models)
-    @eager_load_model_names = Array.wrap(models).map { |model| model.is_a?(Class) ? model.name : model }
+    @eager_load_model_names = Array(models).map { |model| model.is_a?(Class) ? model.name : model }
   end
 
   def self.eager_load_models!

--- a/lib/avromatic/model/nested_models.rb
+++ b/lib/avromatic/model/nested_models.rb
@@ -12,9 +12,20 @@ module Avromatic
       module ClassMethods
         # Register this model if it can be used as a nested model.
         def register!
-          if key_avro_schema.nil? && value_avro_schema.type_sym == :record
-            nested_models.register(self)
+          return unless key_avro_schema.nil? && value_avro_schema.type_sym == :record
+
+          roots = [self]
+          until roots.empty?
+            model = roots.shift
+            next if nested_models.registered?(model)
+
+            nested_models.register(model)
+            roots.concat(model.referenced_models)
           end
+        end
+
+        def referenced_models
+          attribute_definitions.values.flat_map { |definition| definition.type.referenced_models }
         end
       end
     end

--- a/lib/avromatic/model/nested_models.rb
+++ b/lib/avromatic/model/nested_models.rb
@@ -20,12 +20,12 @@ module Avromatic
             next if nested_models.registered?(model)
 
             nested_models.register(model)
-            roots.concat(model.referenced_models)
+            roots.concat(model.referenced_model_classes)
           end
         end
 
-        def referenced_models
-          attribute_definitions.values.flat_map { |definition| definition.type.referenced_models }
+        def referenced_model_classes
+          attribute_definitions.values.flat_map { |definition| definition.type.referenced_model_classes }
         end
       end
     end

--- a/lib/avromatic/model/nested_models.rb
+++ b/lib/avromatic/model/nested_models.rb
@@ -25,7 +25,7 @@ module Avromatic
         end
 
         def referenced_model_classes
-          attribute_definitions.values.flat_map { |definition| definition.type.referenced_model_classes }
+          attribute_definitions.values.flat_map { |definition| definition.type.referenced_model_classes }.freeze
         end
       end
     end

--- a/lib/avromatic/model/types/abstract_type.rb
+++ b/lib/avromatic/model/types/abstract_type.rb
@@ -31,6 +31,10 @@ module Avromatic
         def serialize(_value, **)
           raise "#{__method__} must be overridden by #{self.class.name}"
         end
+
+        def referenced_models
+          raise "#{__method__} must be overridden by #{self.class.name}"
+        end
       end
     end
   end

--- a/lib/avromatic/model/types/abstract_type.rb
+++ b/lib/avromatic/model/types/abstract_type.rb
@@ -4,6 +4,9 @@ module Avromatic
   module Model
     module Types
       class AbstractType
+        EMPTY_ARRAY = [].freeze
+        private_constant :EMPTY_ARRAY
+
         def value_classes
           raise "#{__method__} must be overridden by #{self.class.name}"
         end
@@ -32,7 +35,7 @@ module Avromatic
           raise "#{__method__} must be overridden by #{self.class.name}"
         end
 
-        def referenced_models
+        def referenced_model_classes
           raise "#{__method__} must be overridden by #{self.class.name}"
         end
       end

--- a/lib/avromatic/model/types/array_type.rb
+++ b/lib/avromatic/model/types/array_type.rb
@@ -48,8 +48,8 @@ module Avromatic
           end
         end
 
-        def referenced_models
-          value_type.referenced_models
+        def referenced_model_classes
+          value_type.referenced_model_classes
         end
       end
     end

--- a/lib/avromatic/model/types/array_type.rb
+++ b/lib/avromatic/model/types/array_type.rb
@@ -47,6 +47,10 @@ module Avromatic
             value.map { |element| value_type.serialize(element, strict: strict) }
           end
         end
+
+        def referenced_models
+          value_type.referenced_models
+        end
       end
     end
   end

--- a/lib/avromatic/model/types/boolean_type.rb
+++ b/lib/avromatic/model/types/boolean_type.rb
@@ -33,6 +33,10 @@ module Avromatic
         def serialize(value, **)
           value
         end
+
+        def referenced_models
+          []
+        end
       end
     end
   end

--- a/lib/avromatic/model/types/boolean_type.rb
+++ b/lib/avromatic/model/types/boolean_type.rb
@@ -34,8 +34,8 @@ module Avromatic
           value
         end
 
-        def referenced_models
-          []
+        def referenced_model_classes
+          EMPTY_ARRAY
         end
       end
     end

--- a/lib/avromatic/model/types/custom_type.rb
+++ b/lib/avromatic/model/types/custom_type.rb
@@ -58,6 +58,10 @@ module Avromatic
         def serialize(value, **)
           @serializer.call(value)
         end
+
+        def referenced_models
+          default_type.referenced_models
+        end
       end
     end
   end

--- a/lib/avromatic/model/types/custom_type.rb
+++ b/lib/avromatic/model/types/custom_type.rb
@@ -59,8 +59,8 @@ module Avromatic
           @serializer.call(value)
         end
 
-        def referenced_models
-          default_type.referenced_models
+        def referenced_model_classes
+          default_type.referenced_model_classes
         end
       end
     end

--- a/lib/avromatic/model/types/date_type.rb
+++ b/lib/avromatic/model/types/date_type.rb
@@ -36,8 +36,8 @@ module Avromatic
           value
         end
 
-        def referenced_models
-          []
+        def referenced_model_classes
+          EMPTY_ARRAY
         end
       end
     end

--- a/lib/avromatic/model/types/date_type.rb
+++ b/lib/avromatic/model/types/date_type.rb
@@ -35,6 +35,10 @@ module Avromatic
         def serialize(value, **)
           value
         end
+
+        def referenced_models
+          []
+        end
       end
     end
   end

--- a/lib/avromatic/model/types/enum_type.rb
+++ b/lib/avromatic/model/types/enum_type.rb
@@ -51,8 +51,8 @@ module Avromatic
           value
         end
 
-        def referenced_models
-          []
+        def referenced_model_classes
+          EMPTY_ARRAY
         end
       end
     end

--- a/lib/avromatic/model/types/enum_type.rb
+++ b/lib/avromatic/model/types/enum_type.rb
@@ -50,6 +50,10 @@ module Avromatic
         def serialize(value, **)
           value
         end
+
+        def referenced_models
+          []
+        end
       end
     end
   end

--- a/lib/avromatic/model/types/fixed_type.rb
+++ b/lib/avromatic/model/types/fixed_type.rb
@@ -40,8 +40,8 @@ module Avromatic
           value
         end
 
-        def referenced_models
-          []
+        def referenced_model_classes
+          EMPTY_ARRAY
         end
       end
     end

--- a/lib/avromatic/model/types/fixed_type.rb
+++ b/lib/avromatic/model/types/fixed_type.rb
@@ -39,6 +39,10 @@ module Avromatic
         def serialize(value, **)
           value
         end
+
+        def referenced_models
+          []
+        end
       end
     end
   end

--- a/lib/avromatic/model/types/float_type.rb
+++ b/lib/avromatic/model/types/float_type.rb
@@ -43,8 +43,8 @@ module Avromatic
           value
         end
 
-        def referenced_models
-          []
+        def referenced_model_classes
+          EMPTY_ARRAY
         end
       end
     end

--- a/lib/avromatic/model/types/float_type.rb
+++ b/lib/avromatic/model/types/float_type.rb
@@ -42,6 +42,10 @@ module Avromatic
         def serialize(value, **)
           value
         end
+
+        def referenced_models
+          []
+        end
       end
     end
   end

--- a/lib/avromatic/model/types/integer_type.rb
+++ b/lib/avromatic/model/types/integer_type.rb
@@ -33,6 +33,10 @@ module Avromatic
         def serialize(value, **)
           value
         end
+
+        def referenced_models
+          []
+        end
       end
     end
   end

--- a/lib/avromatic/model/types/integer_type.rb
+++ b/lib/avromatic/model/types/integer_type.rb
@@ -34,8 +34,8 @@ module Avromatic
           value
         end
 
-        def referenced_models
-          []
+        def referenced_model_classes
+          EMPTY_ARRAY
         end
       end
     end

--- a/lib/avromatic/model/types/map_type.rb
+++ b/lib/avromatic/model/types/map_type.rb
@@ -69,8 +69,8 @@ module Avromatic
           end
         end
 
-        def referenced_models
-          [key_type, value_type].tap(&:uniq!).flat_map(&:referenced_models).tap(&:uniq!)
+        def referenced_model_classes
+          [key_type, value_type].tap(&:uniq!).flat_map(&:referenced_model_classes).tap(&:uniq!)
         end
       end
     end

--- a/lib/avromatic/model/types/map_type.rb
+++ b/lib/avromatic/model/types/map_type.rb
@@ -70,7 +70,8 @@ module Avromatic
         end
 
         def referenced_model_classes
-          [key_type, value_type].tap(&:uniq!).flat_map(&:referenced_model_classes).tap(&:uniq!).freeze
+          # According to Avro's spec, keys can only be strings, so we can safely disregard #key_type here.
+          value_type.referenced_model_classes
         end
       end
     end

--- a/lib/avromatic/model/types/map_type.rb
+++ b/lib/avromatic/model/types/map_type.rb
@@ -68,6 +68,10 @@ module Avromatic
             end
           end
         end
+
+        def referenced_models
+          [key_type, value_type].tap(&:uniq!).flat_map(&:referenced_models).tap(&:uniq!)
+        end
       end
     end
   end

--- a/lib/avromatic/model/types/map_type.rb
+++ b/lib/avromatic/model/types/map_type.rb
@@ -70,7 +70,7 @@ module Avromatic
         end
 
         def referenced_model_classes
-          [key_type, value_type].tap(&:uniq!).flat_map(&:referenced_model_classes).tap(&:uniq!)
+          [key_type, value_type].tap(&:uniq!).flat_map(&:referenced_model_classes).tap(&:uniq!).freeze
         end
       end
     end

--- a/lib/avromatic/model/types/null_type.rb
+++ b/lib/avromatic/model/types/null_type.rb
@@ -33,6 +33,10 @@ module Avromatic
         def serialize(_value, **)
           nil
         end
+
+        def referenced_models
+          []
+        end
       end
     end
   end

--- a/lib/avromatic/model/types/null_type.rb
+++ b/lib/avromatic/model/types/null_type.rb
@@ -34,8 +34,8 @@ module Avromatic
           nil
         end
 
-        def referenced_models
-          []
+        def referenced_model_classes
+          EMPTY_ARRAY
         end
       end
     end

--- a/lib/avromatic/model/types/record_type.rb
+++ b/lib/avromatic/model/types/record_type.rb
@@ -52,7 +52,7 @@ module Avromatic
           end
         end
 
-        def referenced_models
+        def referenced_model_classes
           [record_class]
         end
       end

--- a/lib/avromatic/model/types/record_type.rb
+++ b/lib/avromatic/model/types/record_type.rb
@@ -53,7 +53,7 @@ module Avromatic
         end
 
         def referenced_model_classes
-          [record_class]
+          [record_class].freeze
         end
       end
     end

--- a/lib/avromatic/model/types/record_type.rb
+++ b/lib/avromatic/model/types/record_type.rb
@@ -51,6 +51,10 @@ module Avromatic
             strict ? value.avro_value_datum(validate: false) : value.value_attributes_for_avro(validate: false)
           end
         end
+
+        def referenced_models
+          [record_class]
+        end
       end
     end
   end

--- a/lib/avromatic/model/types/string_type.rb
+++ b/lib/avromatic/model/types/string_type.rb
@@ -5,7 +5,7 @@ require 'avromatic/model/types/abstract_type'
 module Avromatic
   module Model
     module Types
-      class StringType
+      class StringType < AbstractType
         VALUE_CLASSES = [::String].freeze
         INPUT_CLASSES = [::String, ::Symbol].freeze
 

--- a/lib/avromatic/model/types/string_type.rb
+++ b/lib/avromatic/model/types/string_type.rb
@@ -43,8 +43,8 @@ module Avromatic
           value
         end
 
-        def referenced_models
-          []
+        def referenced_model_classes
+          EMPTY_ARRAY
         end
       end
     end

--- a/lib/avromatic/model/types/string_type.rb
+++ b/lib/avromatic/model/types/string_type.rb
@@ -42,6 +42,10 @@ module Avromatic
         def serialize(value, **)
           value
         end
+
+        def referenced_models
+          []
+        end
       end
     end
   end

--- a/lib/avromatic/model/types/timestamp_micros_type.rb
+++ b/lib/avromatic/model/types/timestamp_micros_type.rb
@@ -26,6 +26,9 @@ module Avromatic
           ::Time.at(input.to_i, input.usec)
         end
 
+        def referenced_models
+          []
+        end
       end
     end
   end

--- a/lib/avromatic/model/types/timestamp_micros_type.rb
+++ b/lib/avromatic/model/types/timestamp_micros_type.rb
@@ -26,8 +26,8 @@ module Avromatic
           ::Time.at(input.to_i, input.usec)
         end
 
-        def referenced_models
-          []
+        def referenced_model_classes
+          EMPTY_ARRAY
         end
       end
     end

--- a/lib/avromatic/model/types/timestamp_millis_type.rb
+++ b/lib/avromatic/model/types/timestamp_millis_type.rb
@@ -26,6 +26,9 @@ module Avromatic
           ::Time.at(input.to_i, input.usec / 1000 * 1000)
         end
 
+        def referenced_models
+          []
+        end
       end
     end
   end

--- a/lib/avromatic/model/types/timestamp_millis_type.rb
+++ b/lib/avromatic/model/types/timestamp_millis_type.rb
@@ -26,8 +26,8 @@ module Avromatic
           ::Time.at(input.to_i, input.usec / 1000 * 1000)
         end
 
-        def referenced_models
-          []
+        def referenced_model_classes
+          EMPTY_ARRAY
         end
       end
     end

--- a/lib/avromatic/model/types/union_type.rb
+++ b/lib/avromatic/model/types/union_type.rb
@@ -67,6 +67,10 @@ module Avromatic
           hash
         end
 
+        def referenced_models
+          member_types.flat_map(&:referenced_models).tap(&:uniq!)
+        end
+
         private
 
         def find_index(value)

--- a/lib/avromatic/model/types/union_type.rb
+++ b/lib/avromatic/model/types/union_type.rb
@@ -67,8 +67,8 @@ module Avromatic
           hash
         end
 
-        def referenced_models
-          member_types.flat_map(&:referenced_models).tap(&:uniq!)
+        def referenced_model_classes
+          member_types.flat_map(&:referenced_model_classes).tap(&:uniq!)
         end
 
         private

--- a/lib/avromatic/model/types/union_type.rb
+++ b/lib/avromatic/model/types/union_type.rb
@@ -68,7 +68,7 @@ module Avromatic
         end
 
         def referenced_model_classes
-          member_types.flat_map(&:referenced_model_classes).tap(&:uniq!)
+          member_types.flat_map(&:referenced_model_classes).tap(&:uniq!).freeze
         end
 
         private

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Avromatic
-  VERSION = '2.2.1'
+  VERSION = '2.2.2'
 end

--- a/spec/avro/dsl/test/nested_nested_record.rb
+++ b/spec/avro/dsl/test/nested_nested_record.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+namespace :test
+
+record :nested_nested_record do
+  required :str, :string, default: 'A'
+
+  required :sub, :record do
+    required :str, :string, default: 'B'
+    required :i, :int, default: 0
+
+    optional :subsub, :record do
+      required :str, :string, default: 'C'
+      required :i, :int, default: 42
+    end
+  end
+end

--- a/spec/avro/schema/test/nested_nested_record.avsc
+++ b/spec/avro/schema/test/nested_nested_record.avsc
@@ -1,0 +1,56 @@
+{
+  "type": "record",
+  "name": "nested_nested_record",
+  "namespace": "test",
+  "fields": [
+    {
+      "name": "str",
+      "type": "string",
+      "default": "A"
+    },
+    {
+      "name": "sub",
+      "type": {
+        "type": "record",
+        "name": "__nested_nested_record_sub_record",
+        "namespace": "test",
+        "fields": [
+          {
+            "name": "str",
+            "type": "string",
+            "default": "B"
+          },
+          {
+            "name": "i",
+            "type": "int",
+            "default": 0
+          },
+          {
+            "name": "subsub",
+            "type": [
+              "null",
+              {
+                "type": "record",
+                "name": "__nested_nested_record_sub_subsub_record",
+                "namespace": "test",
+                "fields": [
+                  {
+                    "name": "str",
+                    "type": "string",
+                    "default": "C"
+                  },
+                  {
+                    "name": "i",
+                    "type": "int",
+                    "default": 42
+                  }
+                ]
+              }
+            ],
+            "default": null
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/spec/avromatic_spec.rb
+++ b/spec/avromatic_spec.rb
@@ -89,12 +89,6 @@ describe Avromatic do
           described_class.prepare!(skip_clear: true)
           expect(Avromatic.schema_store).not_to have_received(:clear)
         end
-
-        it "doesn't registers nested models" do
-          described_class.eager_load_models = %w(NestedRecord)
-          described_class.prepare!(skip_clear: true)
-          expect(described_class.nested_models.registered?('test.__nested_record_sub_record')).to be(false)
-        end
       end
 
       it "registers models" do

--- a/spec/avromatic_spec.rb
+++ b/spec/avromatic_spec.rb
@@ -80,14 +80,20 @@ describe Avromatic do
       end
 
       context "when skip_clear is true" do
-        before { described_class.prepare!(skip_clear: true) }
-
         it "does not clear the registry" do
+          described_class.prepare!(skip_clear: true)
           expect(described_class.nested_models.registered?('test.value')).to be(true)
         end
 
         it "does not clear the schema store" do
+          described_class.prepare!(skip_clear: true)
           expect(Avromatic.schema_store).not_to have_received(:clear)
+        end
+
+        it "doesn't registers nested models" do
+          described_class.eager_load_models = %w(NestedRecord)
+          described_class.prepare!(skip_clear: true)
+          expect(described_class.nested_models.registered?('test.__nested_record_sub_record')).to be(false)
         end
       end
 
@@ -95,6 +101,12 @@ describe Avromatic do
         described_class.eager_load_models = %w(NestedRecord)
         described_class.prepare!
         expect(described_class.nested_models.registered?('test.value')).to be(false)
+      end
+
+      it "registers nested models" do
+        described_class.eager_load_models = %w(NestedRecord)
+        described_class.prepare!
+        expect(described_class.nested_models.registered?('test.__nested_record_sub_record')).to be(true)
       end
     end
   end

--- a/spec/avromatic_spec.rb
+++ b/spec/avromatic_spec.rb
@@ -51,6 +51,7 @@ describe Avromatic do
   context "eager loading models" do
     before do
       stub_const('NestedRecord', Avromatic::Model.model(schema_name: 'test.nested_record'))
+      stub_const('NestedNestedRecord', Avromatic::Model.model(schema_name: 'test.nested_nested_record'))
       described_class.nested_models.clear
     end
 
@@ -98,9 +99,10 @@ describe Avromatic do
       end
 
       it "registers nested models" do
-        described_class.eager_load_models = %w(NestedRecord)
+        described_class.eager_load_models = %w(NestedNestedRecord)
         described_class.prepare!
-        expect(described_class.nested_models.registered?('test.__nested_record_sub_record')).to be(true)
+        expect(described_class.nested_models.registered?('test.__nested_nested_record_sub_record')).to be(true)
+        expect(described_class.nested_models.registered?('test.__nested_nested_record_sub_subsub_record')).to be(true)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,8 @@ RSpec.configure do |config|
 
     Time.zone = 'GMT'
   end
+
+  config.filter_run_when_matching :focus
 end
 
 # This needs to be required after the before block that sets


### PR DESCRIPTION
Generated nested models register themselves upon being created by
`Avromatic::Model::Builder`. If Rails's autoloader didn't recreate a model that
should be eager loaded, then its nested models won't be registered as we hook on
Railtie `#to_prepare` that itself triggers a clean-up of the nested models
registry.

Therefore, we have to go through the attribute definitions of each eager loaded
model and try to register its nested models.

prime @jturkel 