### PR TITLE
Fake schema registry support for URLs with authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## v2.2.2
+- Fake schema registry support for stubbing URLs with usernames and passwords.
+
 ## v2.2.1
 - Avoid allocating default empty hash in `Avromatic::IO::DatumReader.read_data`
 

--- a/lib/avromatic/rspec.rb
+++ b/lib/avromatic/rspec.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 
+require 'uri'
 require 'webmock/rspec'
 require 'avro_schema_registry/test/fake_server'
 
 RSpec.configure do |config|
   config.before(:each) do
-    WebMock.stub_request(:any, /^#{Avromatic.registry_url}/).to_rack(AvroSchemaRegistry::FakeServer)
+    # Strip the username/password from the URL so WebMock can match the URL
+    registry_uri = URI(Avromatic.registry_url)
+    registry_uri.userinfo = ''
+
+    WebMock.stub_request(:any, /^#{registry_uri}/).to_rack(AvroSchemaRegistry::FakeServer)
     AvroSchemaRegistry::FakeServer.clear
     Avromatic.build_messaging!
   end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Avromatic
-  VERSION = '2.2.1'
+  VERSION = '2.2.2'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ RSpec.configure do |config|
 
   config.before do
     Avromatic.logger = Logger.new('log/test.log')
-    Avromatic.registry_url = 'http://registry.example.com'
+    Avromatic.registry_url = 'http://username:password@registry.example.com'
     Avromatic.use_schema_fingerprint_lookup = true
     Avromatic.schema_store = AvroTurf::SchemaStore.new(path: 'spec/avro/schema')
     Avromatic.custom_type_registry.clear


### PR DESCRIPTION
This adds support for stubbing schema registry URLs with usernames and passwords. Previously the stubbing wouldn't work because the WebMock URL regex was incorrectly including the username/password.