### PR TITLE
Memory optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## v2.2.5
+- Optimize memory usage when serializing, deserializing and instantiating models.
+
 ## v2.2.4
 - Compatibility with Avro v1.10.x.
 

--- a/lib/avromatic/io/datum_reader.rb
+++ b/lib/avromatic/io/datum_reader.rb
@@ -25,7 +25,7 @@ module Avromatic
           optional = readers_schema.schemas.first.type_sym == :null
           union_info = if readers_schema.schemas.size == 2 && optional
                          # Avromatic does not treat the union of null and 1 other type as a union
-                         {}
+                         nil
                        elsif optional
                          # Avromatic does not treat the null of an optional field as part of the union
                          { UNION_MEMBER_INDEX => rs_index - 1 }

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -74,23 +74,23 @@ module Avromatic
       def initialize(data = {})
         super()
 
-        valid_keys = []
+        num_valid_keys = 0
         attribute_definitions.each do |attribute_name, attribute_definition|
           if data.include?(attribute_name)
-            valid_keys << attribute_name
+            num_valid_keys += 1
             value = data.fetch(attribute_name)
             send(attribute_definition.setter_name, value)
           elsif data.include?(attribute_definition.name_string)
-            valid_keys << attribute_name
+            num_valid_keys += 1
             value = data[attribute_definition.name_string]
             send(attribute_definition.setter_name, value)
-          elsif !attributes.include?(attribute_name)
+          elsif !_attributes.include?(attribute_name)
             send(attribute_definition.setter_name, attribute_definition.default)
           end
         end
 
-        unless Avromatic.allow_unknown_attributes || valid_keys.size == data.size
-          unknown_attributes = (data.keys.map(&:to_s) - valid_keys.map(&:to_s)).sort
+        unless Avromatic.allow_unknown_attributes || num_valid_keys == data.size
+          unknown_attributes = (data.keys.map(&:to_s) - _attributes.keys.map(&:to_s)).sort
           allowed_attributes = attribute_definitions.keys.map(&:to_s).sort
           message = "Unexpected arguments for #{self.class.name}#initialize: #{unknown_attributes.join(', ')}. " \
             "Only the following arguments are allowed: #{allowed_attributes.join(', ')}. Provided arguments: #{data.inspect}"

--- a/lib/avromatic/model/raw_serialization.rb
+++ b/lib/avromatic/model/raw_serialization.rb
@@ -55,8 +55,11 @@ module Avromatic
 
         def avro_hash(fields, strict: false, validate:)
           avro_validate! if validate
-          attributes.slice(*fields).each_with_object(Hash.new) do |(key, value), result|
-            result[key.to_s] = attribute_definitions[key].serialize(value, strict: strict)
+          fields.each_with_object(Hash.new) do |field, result|
+            next unless _attributes.include?(field)
+
+            value = _attributes[field]
+            result[field.to_s] = attribute_definitions[field].serialize(value, strict)
           end
         end
 

--- a/lib/avromatic/model/types/abstract_timestamp_type.rb
+++ b/lib/avromatic/model/types/abstract_timestamp_type.rb
@@ -38,7 +38,7 @@ module Avromatic
           value.is_a?(::Time) && value.class != ActiveSupport::TimeWithZone && truncated?(value)
         end
 
-        def serialize(value, **)
+        def serialize(value, _strict)
           value
         end
 

--- a/lib/avromatic/model/types/abstract_type.rb
+++ b/lib/avromatic/model/types/abstract_type.rb
@@ -31,7 +31,9 @@ module Avromatic
           raise "#{__method__} must be overridden by #{self.class.name}"
         end
 
-        def serialize(_value, **)
+        # Note we use positional args rather than keyword args to reduce
+        # memory allocations
+        def serialize(_value, _strict)
           raise "#{__method__} must be overridden by #{self.class.name}"
         end
 

--- a/lib/avromatic/model/types/array_type.rb
+++ b/lib/avromatic/model/types/array_type.rb
@@ -40,11 +40,11 @@ module Avromatic
           value.nil? || (value.is_a?(::Array) && value.all? { |element| value_type.coerced?(element) })
         end
 
-        def serialize(value, strict:)
+        def serialize(value, strict)
           if value.nil?
             value
           else
-            value.map { |element| value_type.serialize(element, strict: strict) }
+            value.map { |element| value_type.serialize(element, strict) }
           end
         end
 

--- a/lib/avromatic/model/types/boolean_type.rb
+++ b/lib/avromatic/model/types/boolean_type.rb
@@ -30,7 +30,7 @@ module Avromatic
 
         alias_method :coerced?, :coercible?
 
-        def serialize(value, **)
+        def serialize(value, _strict)
           value
         end
 

--- a/lib/avromatic/model/types/custom_type.rb
+++ b/lib/avromatic/model/types/custom_type.rb
@@ -55,7 +55,7 @@ module Avromatic
           false
         end
 
-        def serialize(value, **)
+        def serialize(value, _strict)
           @serializer.call(value)
         end
 

--- a/lib/avromatic/model/types/date_type.rb
+++ b/lib/avromatic/model/types/date_type.rb
@@ -32,7 +32,7 @@ module Avromatic
 
         alias_method :coerced?, :coercible?
 
-        def serialize(value, **)
+        def serialize(value, _strict)
           value
         end
 

--- a/lib/avromatic/model/types/enum_type.rb
+++ b/lib/avromatic/model/types/enum_type.rb
@@ -47,7 +47,7 @@ module Avromatic
             (input.is_a?(::Symbol) && allowed_values.include?(input.to_s))
         end
 
-        def serialize(value, **)
+        def serialize(value, _strict)
           value
         end
 

--- a/lib/avromatic/model/types/fixed_type.rb
+++ b/lib/avromatic/model/types/fixed_type.rb
@@ -36,7 +36,7 @@ module Avromatic
 
         alias_method :coerced?, :coercible?
 
-        def serialize(value, **)
+        def serialize(value, _strict)
           value
         end
 

--- a/lib/avromatic/model/types/float_type.rb
+++ b/lib/avromatic/model/types/float_type.rb
@@ -39,7 +39,7 @@ module Avromatic
           input.nil? || input.is_a?(::Float)
         end
 
-        def serialize(value, **)
+        def serialize(value, _strict)
           value
         end
 

--- a/lib/avromatic/model/types/integer_type.rb
+++ b/lib/avromatic/model/types/integer_type.rb
@@ -30,7 +30,7 @@ module Avromatic
 
         alias_method :coerced?, :coercible?
 
-        def serialize(value, **)
+        def serialize(value, _strict)
           value
         end
 

--- a/lib/avromatic/model/types/map_type.rb
+++ b/lib/avromatic/model/types/map_type.rb
@@ -59,12 +59,12 @@ module Avromatic
           end
         end
 
-        def serialize(value, strict:)
+        def serialize(value, strict)
           if value.nil?
             value
           else
             value.each_with_object({}) do |(element_key, element_value), result|
-              result[key_type.serialize(element_key, strict: strict)] = value_type.serialize(element_value, strict: strict)
+              result[key_type.serialize(element_key, strict)] = value_type.serialize(element_value, strict)
             end
           end
         end

--- a/lib/avromatic/model/types/null_type.rb
+++ b/lib/avromatic/model/types/null_type.rb
@@ -30,7 +30,7 @@ module Avromatic
 
         alias_method :coerced?, :coercible?
 
-        def serialize(_value, **)
+        def serialize(_value, _strict)
           nil
         end
 

--- a/lib/avromatic/model/types/record_type.rb
+++ b/lib/avromatic/model/types/record_type.rb
@@ -39,7 +39,7 @@ module Avromatic
           value.nil? || value.is_a?(record_class)
         end
 
-        def serialize(value, strict:)
+        def serialize(value, strict)
           if value.nil?
             value
           elsif !strict && Avromatic.use_custom_datum_writer && Avromatic.use_encoding_providers? && !record_class.config.mutable

--- a/lib/avromatic/model/types/string_type.rb
+++ b/lib/avromatic/model/types/string_type.rb
@@ -39,7 +39,7 @@ module Avromatic
           value.nil? || value.is_a?(::String)
         end
 
-        def serialize(value, **)
+        def serialize(value, _strict)
           value
         end
 

--- a/lib/avromatic/model/types/union_type.rb
+++ b/lib/avromatic/model/types/union_type.rb
@@ -51,7 +51,7 @@ module Avromatic
           end
         end
 
-        def serialize(value, strict:)
+        def serialize(value, strict)
           # Avromatic does not treat the null of an optional field as part of the union
           return nil if value.nil?
 
@@ -60,7 +60,7 @@ module Avromatic
             raise ArgumentError.new("Expected #{value.inspect} to be one of #{value_classes.map(&:name)}")
           end
 
-          hash = member_types[member_index].serialize(value, strict: strict)
+          hash = member_types[member_index].serialize(value, strict)
           if !strict && Avromatic.use_custom_datum_writer && value.is_a?(Avromatic::Model::Attributes)
             hash[Avromatic::IO::UNION_MEMBER_INDEX] = member_index
           end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Avromatic
-  VERSION = '2.2.4'
+  VERSION = '2.2.5'
 end


### PR DESCRIPTION
This PR is part of a series of memory optimizations to our Avro related libraries that reduce serialization memory consumption by 62% and deserialization memory consumption 43% for some of our complex models

A few more details on the optimizations:
* `Avromatic::Model::RawSerialization::Encode#avro_hash` was doing two unnecessary hash allocations
* `Avromatic::Model::Attributes#initialize` was allocating an unnecessary array and hash for each defaulted attribute
* Passing `strict` as a positional argument rather than a keyword argument in `Avromatic::Model::Types::*Type#serialize` avoids a hash allocation on a very hot codepath
* `Avromatic::IO::DatumReader#read_data` was allocating an unnecessary hash for each "optional", non-record attribute value

@will89 - you're prime
/cc @kphelps 