### PR TITLE
[Native] Allow some validations to work.

### DIFF
--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -9,6 +9,7 @@ require 'avromatic/model_registry'
 require 'avromatic/messaging'
 require 'active_support/core_ext/string/inflections'
 require 'avromatic/patches'
+require 'avromatic/native/stubs'
 require 'rutie'
 
 module Avromatic

--- a/lib/avromatic/model/builder.rb
+++ b/lib/avromatic/model/builder.rb
@@ -52,12 +52,8 @@ module Avromatic
           define_included_method
         else
           @config = Avromatic::Model::Configuration.new(**options)
-          define_native_module
+          @mod = AvromaticModel.build(config)
         end
-      end
-
-      def build
-        AvromaticModel.build(schema: config.avro_schema.to_json)
       end
 
       def inclusions
@@ -73,10 +69,6 @@ module Avromatic
       end
 
       private
-
-      def define_native_module
-        @mod = AvromaticModel.build(config)
-      end
 
       def define_included_method
         local_mod = mod

--- a/lib/avromatic/model/builder.rb
+++ b/lib/avromatic/model/builder.rb
@@ -31,6 +31,15 @@ module Avromatic
             super || (@name ||= config.avro_schema.name.classify)
           end
 
+          unless options[:native] == false
+            # TODO: Expand or eliminate this by allowing all inclusions to work and/or replace
+            # with native code.
+            #
+            # TODO: With Ruby code we mixed these directly into the generated module, here we have
+            # to do it for each Model class. Is this OK?
+            include Avromatic::Model::Validation
+          end
+
           class_eval(&block) if block
         end
       end

--- a/lib/avromatic/native/stubs.rb
+++ b/lib/avromatic/native/stubs.rb
@@ -1,0 +1,11 @@
+module Avromatic
+  module Native
+    # Used by native code to return attribute data to mixins, such as validation,
+    # in order to maintain compatibility.
+    module Stubs
+      AttributeDefinition = Struct.new(:name, :field, :required?)
+      Field = Struct.new(:name, :type)
+      Type = Struct.new(:type_sym)
+    end
+  end
+end

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -28,6 +28,55 @@ describe Avromatic::Model::Builder do
     it "has a name" do
       expect(klass.name).to eq('PrimitiveType')
     end
+
+    it "describes its own attribute definitions" do
+      # Minimum compatibility required for validation mixin:
+      summarize = ->(key, attr_def) do
+        [ key, {
+            name: attr_def.name,
+            field: {
+                name: attr_def.field.name,
+                type: {
+                    type_sym: attr_def.field.type.type_sym
+                }
+            },
+            required?: attr_def.required?
+        } ]
+      end
+
+      summary = klass.attribute_definitions.map(&summarize).to_h
+
+      expect(summary).to eq({s: {name: :s,
+                                 field: {name: "s", type: {type_sym: :string}},
+                                 required?: true},
+                             b: {name: :b,
+                                 field: {name: "b", type: {type_sym: :bytes}},
+                                 required?: true},
+                             tf: {name: :tf,
+                                  field: {name: "tf", type: {type_sym: :boolean}},
+                                  required?: true},
+                             i: {name: :i,
+                                 field: {name: "i", type: {type_sym: :int}},
+                                 required?: true},
+                             l: {name: :l,
+                                 field: {name: "l", type: {type_sym: :long}},
+                                 required?: true},
+                             f: {name: :f,
+                                 field: {name: "f", type: {type_sym: :float}},
+                                 required?: true},
+                             d: {name: :d,
+                                 field: {name: "d", type: {type_sym: :double}},
+                                 required?: true},
+                             n: {name: :n,
+                                 field: {name: "n", type: {type_sym: :null}},
+                                 required?: true},
+                             fx: {name: :fx,
+                                  field: {name: "fx", type: {type_sym: :fixed}},
+                                  required?: true},
+                             e: {name: :e,
+                                 field: {name: "e", type: {type_sym: :enum}},
+                                 required?: true}})
+    end
   end
 
   context "model generation" do

--- a/spec/avromatic/model/builder_validation_spec.rb
+++ b/spec/avromatic/model/builder_validation_spec.rb
@@ -280,6 +280,8 @@ describe Avromatic::Model::Builder, 'validation' do
           end
         end
 
+        # TODO: For some reason, this panics only with the variants in the order above. If the variants are reversed,
+        #       it's fine.
         it "validates a record in a union" do
           skip('panics')
           expect(test_class.new(u: 'foo')).to be_valid

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -75,13 +75,13 @@ impl ModelDescriptorInner {
             key.descriptor.attributes.iter().for_each(|(k, key_type)| {
                 if let Some(value_type) = values.get(k) {
                     if value_type != key_type {
-                        let message = format!(
+                        raise!(
+                            "RuntimeError",
                             "Field '{}' has a different type in each schema: {:?} {:?}",
                             k,
                             key_type,
-                            value_type,
+                            value_type
                         );
-                        VM::raise(Class::from_existing("RuntimeError"), &message);
                     }
                 }
             });

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -1,9 +1,4 @@
-use avro_rs::{
-    FullSchema,
-    types::ToAvro,
-    schema::{SchemaKind, SchemaIter, SchemaRef, UnionRef},
-    types::Value as AvroValue,
-};
+use avro_rs::{FullSchema, types::ToAvro, schema::{SchemaKind, SchemaIter, SchemaRef, UnionRef}, types::Value as AvroValue};
 use crate::custom_types::{CustomTypeConfiguration, CustomTypeRegistry};
 use crate::de::*;
 use crate::heap_guard::HeapGuard;
@@ -16,6 +11,7 @@ use rutie::*;
 use std::collections::HashMap;
 use std::io::Read;
 use std::mem::transmute;
+use crate::descriptors::TypeDescriptor::Union;
 
 #[derive(Debug, Fail)]
 pub enum AvromaticError {
@@ -379,6 +375,7 @@ impl AttributeDescriptor {
     pub fn typesym(&self) -> Symbol {
         self.type_descriptor.to_symbol()
     }
+    pub fn is_optional(&self) -> bool { self.type_descriptor.is_optional() }
 }
 
 #[derive(Debug, PartialEq)]
@@ -853,6 +850,18 @@ impl TypeDescriptor {
             TypeDescriptor::Record(_) => Symbol::new("record"),
             TypeDescriptor::Union(_, _) => Symbol::new("union"),
             TypeDescriptor::Custom(_, _) => Symbol::new("custom"),
+        }
+    }
+
+    fn is_optional(&self) -> bool {
+        if let Union(_, variants) = self {
+            if let Some(&TypeDescriptor::Null) = variants.first() {
+                true
+            } else {
+                false
+            }
+        } else {
+            false
         }
     }
 }

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -375,6 +375,10 @@ impl AttributeDescriptor {
     {
         self.type_descriptor.serialize(value, schema)
     }
+
+    pub fn typesym(&self) -> Symbol {
+        self.type_descriptor.to_symbol()
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -825,6 +829,30 @@ impl TypeDescriptor {
                 let raw = default.decode(reader)?;
                 Ok(inner.deserialize(raw))
             }
+        }
+    }
+
+    pub fn to_symbol(&self) -> Symbol {
+        // TODO: Figure out the exhaustive list of typesyms.
+        match self {
+            TypeDescriptor::Boolean => Symbol::new("boolean"),
+            TypeDescriptor::Enum(_) => Symbol::new("enum"),
+            TypeDescriptor::Fixed(_) => Symbol::new("fixed"),
+            TypeDescriptor::Float => Symbol::new("float"),
+            TypeDescriptor::Double => Symbol::new("double"),
+            TypeDescriptor::Int => Symbol::new("int"),
+            TypeDescriptor::Long => Symbol::new("long"),
+            TypeDescriptor::Null => Symbol::new("null"),
+            TypeDescriptor::String => Symbol::new("string"),
+            TypeDescriptor::Bytes => Symbol::new("bytes"),
+            TypeDescriptor::Date => Symbol::new("date"),
+            TypeDescriptor::TimestampMicros => Symbol::new("timestampmicros"),
+            TypeDescriptor::TimestampMillis => Symbol::new("timestampmillis"),
+            TypeDescriptor::Array(_) => Symbol::new("array"),
+            TypeDescriptor::Map(_) => Symbol::new("map"),
+            TypeDescriptor::Record(_) => Symbol::new("record"),
+            TypeDescriptor::Union(_, _) => Symbol::new("union"),
+            TypeDescriptor::Custom(_, _) => Symbol::new("custom"),
         }
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,11 +1,10 @@
-
 macro_rules! argument_check {
     ($inner:expr) => {
         match $inner {
             Ok(value) => value,
             Err(e) => {
-                let message = format!("Bad argument: {}", e);
-                rutie::VM::raise(rutie::Class::from_existing("ArgumentError"), &message);
+                raise!("ArgumentError", "Bad argument: {}", e);
+
                 return rutie::NilClass::new().into();
             }
         }
@@ -17,8 +16,8 @@ macro_rules! rb_try {
         match $inner {
             Ok(value) => value,
             Err(e) => {
-                let message = format!("{}", e);
-                rutie::VM::raise(rutie::Class::from_existing("StandardError"), &message);
+                raise!("StandardError", e);
+
                 return rutie::NilClass::new().into();
             }
         }
@@ -128,5 +127,40 @@ macro_rules! ruby_class {
                 concat!("Error converting to ", $ruby_name)
             }
         }
+    };
+}
+
+macro_rules! varargs {
+    ($fmt:literal, $argc:expr, $argv:expr, $( $ident: ident ),*) => {
+        $(
+            let $ident = RValue::from(0);
+        )*
+
+        unsafe {
+            let p_argv: *const RValue = std::mem::transmute($argv);
+
+            rutie::rubysys::class::rb_scan_args(
+                $argc,
+                p_argv,
+                rutie::util::str_to_cstring($fmt).as_ptr(),
+                $(
+                    &$ident,
+                )*
+            );
+        };
+    };
+}
+
+macro_rules! raise {
+    ($class: literal, $displayable: expr) => {
+        raise!($class, "{}", $displayable);
+    };
+
+    ($class: literal, $fmt: literal, $( $placeholder: expr ),*) => {
+        let class = Class::from(rutie::util::inmost_rb_object($class));
+
+        let message = format!($fmt, $( $placeholder, )*);
+
+        rutie::VM::raise(class, &message);
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -25,6 +25,21 @@ macro_rules! rb_try {
     }
 }
 
+/// Raise an AnyException from a Result<AnyObject, AnyException> if one is present and return
+/// nil as AnyObject from current function.
+macro_rules! rb_try_ex {
+    ($inner:expr) => {
+        match $inner {
+            Ok(value) => value,
+            Err(e) => {
+                rutie::VM::raise_ex(e);
+                return rutie::NilClass::new().into();
+            }
+        }
+    }
+}
+
+
 macro_rules! ruby_class {
     ($rust_name:ident, $ruby_name:expr) => {
         ruby_class!($rust_name, $ruby_name, Class::from_existing($ruby_name));


### PR DESCRIPTION
@kphelps prime, because I'm not sure how crazy this approach is. Essentially I'm trying to stub enough data over to the existing mixins for them to do the validation logic as they do today. This fixes something like 8 test cases. Validations around nested objects and unions are still failing, but I think we have issues with nesting and unions in general in the class builder.