### PR TITLE
Fix immutable caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # avromatic changelog
 
-## v2.4.0
+## Unreleased
 - Don't cache immutable model validation results or serialized Avro attributes if a model has mutable children.
 
 ## v2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## v2.4.0
+- Don't cache immutable model validation results or serialized Avro attributes if a model has mutable children.
+
 ## v2.3.0
 - Add support for Rails 6.1.
 - Optimize nested model serialization.

--- a/lib/avromatic/model/attributes.rb
+++ b/lib/avromatic/model/attributes.rb
@@ -28,6 +28,7 @@ module Avromatic
           @owner = owner
           @field = field
           @type = type
+          @values_immutable = type.referenced_model_classes.all?(&:recursively_immutable?)
           @name = field.name.to_sym
           @name_string = field.name.to_s.dup.freeze
           @setter_name = "#{field.name}=".to_sym
@@ -42,6 +43,10 @@ module Avromatic
 
         def required?
           FieldHelper.required?(field)
+        end
+
+        def values_immutable?
+          @values_immutable
         end
 
         def coerce(input)
@@ -69,6 +74,8 @@ module Avromatic
       included do
         class_attribute :attribute_definitions, instance_writer: false
         self.attribute_definitions = {}
+
+        delegate :recursively_immutable?, to: :class
       end
 
       def initialize(data = {})
@@ -130,6 +137,12 @@ module Avromatic
           define_avro_attributes(avro_schema, generated_methods_module)
         end
 
+        def recursively_immutable?
+          return @recursively_immutable if defined?(@recursively_immutable)
+
+          @recursively_immutable = immutable? && attribute_definitions.each_value.all?(&:values_immutable?)
+        end
+
         private
 
         def check_for_field_conflicts!
@@ -177,7 +190,7 @@ module Avromatic
               _attributes[symbolized_field_name] = attribute_definitions[symbolized_field_name].coerce(value)
             end
 
-            unless config.mutable # rubocop:disable Style/Next
+            unless mutable? # rubocop:disable Style/Next
               generated_methods_module.send(:private, "#{field.name}=")
               generated_methods_module.send(:define_method, :clone) { self }
               generated_methods_module.send(:define_method, :dup) { self }

--- a/lib/avromatic/model/configurable.rb
+++ b/lib/avromatic/model/configurable.rb
@@ -19,9 +19,12 @@ module Avromatic
         end
       end
 
+      included do
+        class_attribute :config, instance_accessor: false, instance_predicate: false
+      end
+
       module ClassMethods
-        attr_accessor :config
-        delegate :avro_schema, :value_avro_schema, :key_avro_schema, to: :config
+        delegate :avro_schema, :value_avro_schema, :key_avro_schema, :mutable?, :immutable?, to: :config
 
         def value_avro_field_names
           @value_avro_field_names ||= value_avro_schema.fields.map(&:name).map(&:to_sym).freeze
@@ -67,6 +70,7 @@ module Avromatic
       delegate :avro_schema, :value_avro_schema, :key_avro_schema,
                :value_avro_field_names, :key_avro_field_names,
                :value_avro_field_references, :key_avro_field_references,
+               :mutable?, :immutable?,
                to: :class
     end
   end

--- a/lib/avromatic/model/configuration.rb
+++ b/lib/avromatic/model/configuration.rb
@@ -8,6 +8,7 @@ module Avromatic
 
       attr_reader :avro_schema, :key_avro_schema, :nested_models, :mutable,
                   :allow_optional_key_fields
+      alias_method :mutable?, :mutable
       delegate :schema_store, to: Avromatic
 
       # Either schema(_name) or value_schema(_name), but not both, must be
@@ -33,6 +34,10 @@ module Avromatic
       end
 
       alias_method :value_avro_schema, :avro_schema
+
+      def immutable?
+        !mutable?
+      end
 
       private
 

--- a/lib/avromatic/model/raw_serialization.rb
+++ b/lib/avromatic/model/raw_serialization.rb
@@ -15,10 +15,10 @@ module Avromatic
         private :datum_writer, :datum_reader
 
         def avro_raw_value(validate: true)
-          if self.class.config.mutable
-            avro_raw_encode(value_attributes_for_avro(validate: validate), :value)
-          else
+          if self.class.recursively_immutable?
             @avro_raw_value ||= avro_raw_encode(value_attributes_for_avro(validate: validate), :value)
+          else
+            avro_raw_encode(value_attributes_for_avro(validate: validate), :value)
           end
         end
 
@@ -28,10 +28,10 @@ module Avromatic
         end
 
         def value_attributes_for_avro(validate: true)
-          if self.class.config.mutable
-            avro_hash(value_avro_field_references, validate: validate)
-          else
+          if self.class.recursively_immutable?
             @value_attributes_for_avro ||= avro_hash(value_avro_field_references, validate: validate)
+          else
+            avro_hash(value_avro_field_references, validate: validate)
           end
         end
 
@@ -40,10 +40,10 @@ module Avromatic
         end
 
         def avro_value_datum(validate: true)
-          if self.class.config.mutable
-            avro_hash(value_avro_field_references, strict: true, validate: validate)
+          if self.class.recursively_immutable?
+            @avro_value_datum ||= avro_hash(value_avro_field_references, strict: true, validate: validate)
           else
-            @avro_datum ||= avro_hash(value_avro_field_references, strict: true, validate: validate)
+            avro_hash(value_avro_field_references, strict: true, validate: validate)
           end
         end
 

--- a/lib/avromatic/model/validation.rb
+++ b/lib/avromatic/model/validation.rb
@@ -64,8 +64,8 @@ module Avromatic
           end
         end
 
-        unless self.class.config.mutable
-          @missing_attributes = missing_attributes.deep_freeze
+        if recursively_immutable?
+          @missing_attributes = missing_attributes.freeze
         end
 
         missing_attributes

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Avromatic
-  VERSION = '2.4.0'
+  VERSION = '2.3.0'
 end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Avromatic
-  VERSION = '2.3.0'
+  VERSION = '2.4.0'
 end


### PR DESCRIPTION
This PR fixes a bug where Avromatic was incorrectly caching validation results and serialized attributes when an immutable model had mutable children. I noticed this while working on #131.

/cc @askreet