### PR TITLE
C++ Encoding/Decoding POC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,30 @@ jobs:
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
+      - restore_cache:
+          name: Restore Avro C++ Cache
+          keys:
+            - v1-avro-cpp-1.10.1
+      - run:
+          name: Install Avro C++
+          command: |
+            # TODO: Add this to our Docker images
+            sudo apt-get -y install cmake libboost-dev libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev libboost-system-dev
+            if [ ! -d avro-cpp-1.10.1 ]; then
+              wget http://apache.mirrors.spacedump.net/avro/stable/cpp/avro-cpp-1.10.1.tar.gz
+              tar -xzvf avro-cpp-1.10.1.tar.gz
+            fi
+            cd avro-cpp-1.10.1/
+            sudo ./build.sh install
+      - save_cache:
+          name: Save Avro C++ Cache
+          key: v1-avro-cpp-1.10.1
+          paths:
+            - "avro-cpp-1.10.1"
+      - run:
+          name: Compile Native Extension
+          command: |
+            bundle exec rake compile
       - run:
           name: Run Rubocop
           command: bundle exec rubocop
@@ -55,6 +79,30 @@ jobs:
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
+      - restore_cache:
+          name: Restore Avro C++ Cache
+          keys:
+            - v1-avro-cpp-1.10.1
+      - run:
+          name: Install Avro C++
+          command: |
+            # TODO: Add this to our Docker images
+            sudo apt-get -y install cmake libboost-dev libboost-filesystem-dev libboost-iostreams-dev libboost-program-options-dev libboost-system-dev
+            if [ ! -d avro-cpp-1.10.1 ]; then
+              wget http://apache.mirrors.spacedump.net/avro/stable/cpp/avro-cpp-1.10.1.tar.gz
+              tar -xzvf avro-cpp-1.10.1.tar.gz
+            fi
+            cd avro-cpp-1.10.1/
+            sudo ./build.sh install
+      - save_cache:
+          name: Save Avro C++ Cache
+          key: v1-avro-cpp-1.10.1
+          paths:
+            - "avro-cpp-1.10.1"
+      - run:
+          name: Compile Native Extension
+          command: |
+            bundle exec rake compile
       - run:
           name: Run Tests
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /tmp/
 /gemfiles/*.lock
 /log/*
+avromatic.bundle

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,11 @@ require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'appraisal/task'
 require 'avro/builder'
+require 'rake/extensiontask'
+
+Rake::ExtensionTask.new('avromatic') do |ext|
+  ext.lib_dir = 'lib/avromatic'
+end
 
 RSpec::Core::RakeTask.new(:default_spec)
 

--- a/avromatic.gemspec
+++ b/avromatic.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.extensions = ['ext/avromatic/extconf.rb']
 
   spec.required_ruby_version = '>= 2.4'
 
@@ -34,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.11'
   spec.add_development_dependency 'overcommit', '0.35.0'
   spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake-compiler'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'salsify_rubocop', '~> 0.52.1.1'

--- a/ext/avromatic/avromatic.cpp
+++ b/ext/avromatic/avromatic.cpp
@@ -1,0 +1,17 @@
+#include <ruby.h>
+#include <encoder.hpp>
+#include <decoder.hpp>
+
+extern "C"
+void Init_avromatic() {
+  VALUE avromatic = rb_define_module("Avromatic");
+  VALUE avromatic_io = rb_define_module_under(avromatic, "IO");
+  VALUE avromatic_native = rb_define_module_under(avromatic_io, "Native");
+
+  VALUE date_class = rb_const_get(rb_cObject, rb_intern("Date"));
+  VALUE rb_epoch_start = rb_funcall(date_class, rb_intern("new"), 3, INT2NUM(1970), INT2NUM(1), INT2NUM(1));
+  rb_const_set(avromatic_native, rb_intern("EPOCH_START"), rb_epoch_start);
+
+  init_avromatic_encoder(avromatic_native);
+  init_avromatic_decoder(avromatic_native);
+}

--- a/ext/avromatic/common.cpp
+++ b/ext/avromatic/common.cpp
@@ -1,0 +1,53 @@
+#include <common.hpp>
+#include <avro/Compiler.hh>
+#include <avro/ValidSchema.hh>
+#include <iostream>
+
+void native_schema_free(void* data) {
+  delete (avro::ValidSchema*)data;
+}
+
+size_t native_schema_size(const void* data) {
+  return sizeof(avro::ValidSchema);
+}
+
+static const rb_data_type_t native_schema_type = {
+  .wrap_struct_name = "native_schema",
+  .function = {
+    .dmark = NULL,
+    .dfree = native_schema_free,
+    .dsize = native_schema_size,
+  },
+  .data = NULL,
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
+
+VALUE create_native_schema_wrapper(VALUE rb_avro_schema) {
+  VALUE rb_avro_schema_json = rb_funcall(rb_avro_schema, rb_intern("to_s"), 0);
+  avro::ValidSchema* schema;
+  try {
+    avro::ValidSchema source_schema = avro::compileJsonSchemaFromString(StringValueCStr(rb_avro_schema_json));
+    schema = new avro::ValidSchema(source_schema);
+  } catch (const avro::Exception &e) {
+    // This should never happen since the schema was valid in Ruby Avro
+    rb_raise(rb_eRuntimeError, "Failed to compile native Avro schema '%s': %s", StringValueCStr(rb_avro_schema_json), e.what());
+    // Make the compiler happy
+    schema = NULL;
+  }
+
+  // Wrap the C++ object so it can be garbage collected by Ruby
+  return TypedData_Wrap_Struct(RBASIC_CLASS(rb_avro_schema), &native_schema_type, schema);
+}
+
+const avro::ValidSchema* get_cached_schema(VALUE rb_avro_schema) {
+  VALUE native_schema_wrapper = rb_iv_get(rb_avro_schema, "@native_schema");
+  if (native_schema_wrapper == Qnil) {
+    std::cout << "Schema cache miss for Avro schema " << rb_avro_schema << std::endl;
+    native_schema_wrapper = create_native_schema_wrapper(rb_avro_schema);
+    rb_iv_set(rb_avro_schema, "@native_schema", native_schema_wrapper);
+  }
+
+  avro::ValidSchema* schema;
+  TypedData_Get_Struct(native_schema_wrapper, avro::ValidSchema, &native_schema_type, schema);
+  return schema;
+}

--- a/ext/avromatic/common.hpp
+++ b/ext/avromatic/common.hpp
@@ -1,0 +1,14 @@
+#ifndef AVROMATIC_COMMON
+#define AVROMATIC_COMMON
+
+#include <ruby.h>
+
+namespace avro {
+  class ValidSchema;
+}
+
+#define RB_FUNC(FUNCTION) reinterpret_cast<VALUE(*)(...)>(FUNCTION)
+
+const avro::ValidSchema* get_cached_schema(VALUE rb_avro_schema);
+
+#endif

--- a/ext/avromatic/decoder.cpp
+++ b/ext/avromatic/decoder.cpp
@@ -1,0 +1,192 @@
+#include <encoder.hpp>
+#include <common.hpp>
+
+#include <iostream>
+
+#include <ruby/encoding.h>
+
+#include <avro/Decoder.hh>
+#include <avro/Generic.hh>
+#include <avro/GenericDatum.hh>
+#include <avro/Specific.hh>
+
+static VALUE rb_avromatic_native_module;
+static VALUE rb_union_datum_class;
+
+VALUE utf8_string_to_ruby(const std::string& value) {
+  static rb_encoding* encoding = rb_enc_find("UTF-8");
+  return rb_enc_str_new(value.c_str(), value.size(), encoding);
+}
+
+VALUE deserialize_logical_date(int value) {
+  VALUE rb_epoch_start = rb_const_get(rb_avromatic_native_module, rb_intern("EPOCH_START"));
+  return rb_funcall(rb_epoch_start, rb_intern("+"), 1, INT2NUM(value));
+}
+
+VALUE deserialize_logical_timestamp_millis(long value) {
+  long seconds = value / 1000;
+  long milliseconds = value % 1000;
+  VALUE time_class = rb_const_get(rb_cObject, rb_intern("Time"));
+  VALUE rb_value = rb_funcall(time_class, rb_intern("at"), 2, LONG2NUM(seconds), LONG2NUM(milliseconds * 1000));
+  return rb_funcall(rb_value, rb_intern("utc"), 0);
+}
+
+VALUE deserialize_logical_timestamp_micros(long value) {
+  long seconds = value / 1000000;
+  long microseconds = value % 1000000;
+  VALUE time_class = rb_const_get(rb_cObject, rb_intern("Time"));
+  VALUE rb_value = rb_funcall(time_class, rb_intern("at"), 2, LONG2NUM(seconds), LONG2NUM(microseconds));
+  return rb_funcall(rb_value, rb_intern("utc"), 0);
+}
+
+bool is_optional_field(const avro::NodePtr& schema) {
+  return schema->type() == avro::AVRO_UNION &&
+    schema->leafAt(0)->type() == avro::AVRO_NULL &&
+    schema->leaves() == 2;
+}
+
+// Unfortunately we need to track the schema for unions due to https://issues.apache.org/jira/browse/AVRO-2597
+VALUE datum_to_ruby_value(const avro::NodePtr& schema, const avro::GenericDatum& datum, bool strict) {
+  VALUE rb_value;
+  switch (datum.type()) {
+    case avro::AVRO_STRING:
+    {
+      const std::string& field_value = datum.value<std::string>();
+      rb_value = utf8_string_to_ruby(field_value);
+      break;
+    }
+    case avro::AVRO_BYTES:
+    {
+      const std::vector<uint8_t>& bytes = datum.value<std::vector<uint8_t> >();
+      rb_value = rb_str_new((const char*)&bytes[0], bytes.size());
+      break;
+    }
+    case avro::AVRO_INT:
+    {
+      if (datum.logicalType().type() == avro::LogicalType::DATE) {
+        rb_value = deserialize_logical_date(datum.value<int>());
+      } else {
+        rb_value = INT2NUM(datum.value<int>());
+      }
+      break;
+    }
+    case avro::AVRO_LONG:
+    {
+      if (datum.logicalType().type() == avro::LogicalType::TIMESTAMP_MILLIS) {
+        rb_value = deserialize_logical_timestamp_millis(datum.value<long>());
+      } else if (datum.logicalType().type() == avro::LogicalType::TIMESTAMP_MICROS) {
+        rb_value = deserialize_logical_timestamp_micros(datum.value<long>());
+      } else {
+        rb_value = LONG2NUM(datum.value<long>());
+      }
+      break;
+    }
+    case avro::AVRO_FLOAT:
+    {
+      rb_value = DBL2NUM(datum.value<float>());
+      break;
+    }
+    case avro::AVRO_DOUBLE:
+    {
+      rb_value = DBL2NUM(datum.value<double>());
+      break;
+    }
+    case avro::AVRO_BOOL:
+    {
+      rb_value = datum.value<bool>() ? Qtrue : Qfalse;
+      break;
+    }
+    case avro::AVRO_NULL:
+    {
+      rb_value = Qnil;
+      break;
+    }
+    case avro::AVRO_RECORD:
+    {
+      rb_value = rb_hash_new();
+      const avro::GenericRecord& record_value = datum.value<avro::GenericRecord>();
+      const int num_fields = (int)record_value.fieldCount();
+      for (int i=0; i<num_fields; ++i) {
+        const std::string& field_name = record_value.schema()->nameAt(i);
+        VALUE rb_field_name = ID2SYM(rb_intern(field_name.c_str()));
+        const avro::GenericDatum& field_datum = record_value.fieldAt(i);
+        rb_hash_aset(rb_value, rb_field_name, datum_to_ruby_value(record_value.schema()->leafAt(i), field_datum, strict));
+      }
+      break;
+    }
+    case avro::AVRO_ENUM:
+    {
+      const std::string& symbol = datum.value<avro::GenericEnum>().symbol();
+      rb_value = ID2SYM(rb_intern(symbol.c_str()));
+      break;
+    }
+    case avro::AVRO_ARRAY:
+    {
+      const avro::GenericArray::Value& array_value = datum.value<avro::GenericArray>().value();
+      const long num_elements = array_value.size();
+      rb_value = rb_ary_new_capa(num_elements);
+      for (long i=0; i<num_elements; ++i) {
+        rb_ary_store(rb_value, i, datum_to_ruby_value(schema->leafAt(0), array_value[i], strict));
+      }
+      break;
+    }
+    case avro::AVRO_MAP:
+    {
+      rb_value = rb_hash_new();
+      const avro::GenericMap::Value& map_entries = datum.value<avro::GenericMap>().value();
+      for (auto iter = map_entries.cbegin(); iter != map_entries.cend(); ++iter) {
+        VALUE rb_map_key = utf8_string_to_ruby(iter->first);
+        VALUE rb_map_value = datum_to_ruby_value(schema->leafAt(1), iter->second, strict);
+        rb_hash_aset(rb_value, rb_map_key, rb_map_value);
+      }
+     break;
+    }
+    case avro::AVRO_FIXED:
+    {
+      const avro::GenericFixed& fixedValue = datum.value<avro::GenericFixed>();
+      const std::vector<uint8_t>& bytes = fixedValue.value();
+      rb_value = rb_str_new((const char*)&bytes[0], bytes.size());
+      break;
+    }
+    default:
+      rb_raise(rb_eRuntimeError, "Unexpected field type %s", avro::toString(datum.type()).c_str());
+      // Make the compiler happy
+      rb_value = Qnil;
+  }
+
+  if (!strict && schema->type() == avro::AVRO_UNION && !is_optional_field(schema) && datum.type() != avro::AVRO_NULL) {
+    long member_index = schema->leafAt(0)->type() == avro::AVRO_NULL ? datum.unionBranch() - 1 : datum.unionBranch();
+    return rb_funcall(rb_union_datum_class, rb_intern("new"), 2, LONG2NUM(member_index), rb_value);
+  } else {
+    return rb_value;
+  }
+}
+
+VALUE decode_attributes(VALUE self, VALUE rb_data, VALUE rb_reader_schema, VALUE rb_writer_schema, VALUE rb_strict) {
+  const char* raw_bytes = StringValuePtr(rb_data);
+  const size_t num_bytes = RSTRING_LEN(rb_data);
+  std::unique_ptr<avro::InputStream> inputStream = avro::memoryInputStream((uint8_t*)raw_bytes, num_bytes);
+
+  const avro::ValidSchema* reader_schema = get_cached_schema(rb_reader_schema);
+  avro::DecoderPtr decoder = avro::validatingDecoder(*reader_schema, avro::binaryDecoder());
+  if (rb_reader_schema != rb_writer_schema) {
+    const avro::ValidSchema* writer_schema = get_cached_schema(rb_writer_schema);
+    decoder = avro::resolvingDecoder(*writer_schema, *reader_schema, decoder);
+  }
+  decoder->init(*inputStream);
+
+  avro::GenericDatum datum(*reader_schema);
+  avro::decode(*decoder, datum);
+
+  return datum_to_ruby_value(reader_schema->root(), datum, rb_strict == Qtrue);
+}
+
+extern
+void init_avromatic_decoder(VALUE avromatic_native) {
+  rb_avromatic_native_module = avromatic_native;
+  rb_define_singleton_method(avromatic_native, "decode_attributes", RB_FUNC(decode_attributes), 4);
+
+  VALUE rb_avromatic_module = rb_const_get(rb_cObject, rb_intern("Avromatic"));
+  VALUE rb_model_module = rb_const_get(rb_avromatic_module, rb_intern("IO"));
+  rb_union_datum_class = rb_const_get(rb_model_module, rb_intern("UnionDatum"));
+}

--- a/ext/avromatic/decoder.hpp
+++ b/ext/avromatic/decoder.hpp
@@ -1,0 +1,8 @@
+#ifndef AVROMATIC_DECODER
+#define AVROMATIC_DECODER
+
+#include <ruby.h>
+
+void init_avromatic_decoder(VALUE avromatic_native);
+
+#endif

--- a/ext/avromatic/encoder.cpp
+++ b/ext/avromatic/encoder.cpp
@@ -1,0 +1,267 @@
+#include <encoder.hpp>
+#include <common.hpp>
+
+#include <iostream>
+
+#include <avro/Encoder.hh>
+#include <avro/Generic.hh>
+#include <avro/GenericDatum.hh>
+#include <avro/Specific.hh>
+
+static VALUE rb_avromatic_native_module;
+static VALUE rb_avromatic_custom_type_class;
+static VALUE rb_avromatic_union_type_class;
+static VALUE rb_avromatic_validation_error_class;
+
+class MissingRequiredAttributeException : public virtual std::runtime_error {
+  public:
+    MissingRequiredAttributeException(const std::string &msg) :
+        std::runtime_error(msg)
+    { }
+};
+
+void ruby_model_to_datum(VALUE model, avro::GenericDatum& datum, bool is_value_schema = true);
+
+bool is_union_type(VALUE rb_avromatic_type) {
+  return rb_obj_is_kind_of(rb_avromatic_type, rb_avromatic_union_type_class) == Qtrue;
+}
+
+VALUE serialize_custom_type(VALUE rb_value, VALUE rb_avromatic_type) {
+  if (rb_value != Qnil && rb_obj_is_kind_of(rb_avromatic_type, rb_avromatic_custom_type_class) == Qtrue) {
+    return rb_funcall(rb_avromatic_type, rb_intern("serialize"), 2, rb_value, Qtrue);
+  } else {
+    return rb_value;
+  }
+}
+
+int serialize_logical_date(VALUE rb_value) {
+  VALUE numeric_class = rb_const_get(rb_cObject, rb_intern("Numeric"));
+  if (rb_obj_is_kind_of(rb_value, numeric_class) == Qtrue) {
+    return NUM2INT(rb_funcall(rb_value, rb_intern("to_i"), 0));
+  } else {
+    VALUE rb_epoch_start = rb_const_get(rb_avromatic_native_module, rb_intern("EPOCH_START"));
+    VALUE rb_time_since_epoch = rb_funcall(rb_value, rb_intern("-"), 1, rb_epoch_start);
+    return NUM2INT(rb_funcall(rb_time_since_epoch, rb_intern("to_i"), 0));
+  }
+}
+
+long serialize_logical_timestamp_millis(VALUE rb_value) {
+  VALUE numeric_class = rb_const_get(rb_cObject, rb_intern("Numeric"));
+  if (rb_obj_is_kind_of(rb_value, numeric_class) == Qtrue) {
+    return NUM2LONG(rb_funcall(rb_value, rb_intern("to_i"), 0));
+  } else {
+    VALUE rb_time = rb_funcall(rb_value, rb_intern("to_time"), 0);
+    long seconds = NUM2LONG(rb_funcall(rb_time, rb_intern("to_i"), 0));
+    long microseconds = NUM2LONG(rb_funcall(rb_time, rb_intern("usec"), 0));
+    return seconds * 1000 + microseconds / 1000;
+  }
+}
+
+long serialize_logical_timestamp_micros(VALUE rb_value) {
+  VALUE numeric_class = rb_const_get(rb_cObject, rb_intern("Numeric"));
+  if (rb_obj_is_kind_of(rb_value, numeric_class) == Qtrue) {
+    return NUM2LONG(rb_funcall(rb_value, rb_intern("to_i"), 0));
+  } else {
+    VALUE rb_time = rb_funcall(rb_value, rb_intern("to_time"), 0);
+    long seconds = NUM2LONG(rb_funcall(rb_time, rb_intern("to_i"), 0));
+    long microseconds = NUM2LONG(rb_funcall(rb_time, rb_intern("usec"), 0));
+    return seconds *  1000000 + microseconds;
+  }
+}
+
+void ruby_value_to_datum(VALUE rb_value, VALUE rb_avromatic_type, avro::GenericDatum& datum) {
+  // TODO: This doesn't support custom records that return record types
+  rb_value = serialize_custom_type(rb_value, rb_avromatic_type);
+
+  if (rb_value == Qnil && datum.type() != avro::AVRO_NULL) {
+    throw MissingRequiredAttributeException("Unexpected nil field value for type " + avro::toString(datum.type()));
+  }
+
+  // Make sure we select the correct branch of the union. Avromatic only allows nils as the first branch of a union
+  // so there's nothing to do if we're encoding a null
+  if (datum.isUnion() && rb_value != Qnil) {
+    if (!is_union_type(rb_avromatic_type)) {
+      // Avromatic doesn't model optional fields as unions even though they're unions in the Avro schema
+      // so rb_avromatic_type will be the actual member type
+      datum.selectBranch(1);
+    } else {
+      int avromatic_member_index = NUM2INT(rb_funcall(rb_avromatic_type, rb_intern("find_index"), 1, rb_value));
+      // Avromatic doesn't include the null member in the member index
+      int member_index = rb_funcall(rb_avromatic_type, rb_intern("nullable?"), 0) == Qtrue ? avromatic_member_index + 1 : avromatic_member_index;
+      datum.selectBranch(member_index);
+
+      VALUE rb_avromatic_member_types = rb_funcall(rb_avromatic_type, rb_intern("member_types"), 0);
+      rb_avromatic_type = rb_ary_entry(rb_avromatic_member_types, avromatic_member_index);
+    }
+  }
+
+  switch (datum.type()) {
+    case avro::AVRO_STRING:
+    {
+      VALUE rb_utf8_string = rb_funcall(rb_value, rb_intern("encode"), 1, rb_id2str(rb_intern("utf-8")));
+      // TODO: Does this work correctly with utf-8 characters?
+      datum.value<std::string>() = StringValueCStr(rb_utf8_string);
+      break;
+    }
+    case avro::AVRO_BYTES:
+    {
+      const char* raw_bytes = StringValuePtr(rb_value);
+      const size_t num_bytes = RSTRING_LEN(rb_value);
+      std::vector<uint8_t>& destination_buffer = datum.value<std::vector<uint8_t> >();
+      destination_buffer.reserve(num_bytes);
+      destination_buffer.assign(raw_bytes, raw_bytes + num_bytes);
+      break;
+    }
+    case avro::AVRO_INT:
+    {
+      if (datum.logicalType().type() == avro::LogicalType::DATE) {
+        datum.value<int>() = serialize_logical_date(rb_value);
+      } else {
+        datum.value<int>() = NUM2INT(rb_value);
+      }
+      break;
+    }
+    case avro::AVRO_LONG:
+    {
+      if (datum.logicalType().type() == avro::LogicalType::TIMESTAMP_MILLIS) {
+        datum.value<long>() = serialize_logical_timestamp_millis(rb_value);
+      } else if (datum.logicalType().type() == avro::LogicalType::TIMESTAMP_MICROS) {
+        datum.value<long>() = serialize_logical_timestamp_micros(rb_value);
+      } else {
+        datum.value<long>() = NUM2LONG(rb_value);
+      }
+      break;
+    }
+    case avro::AVRO_FLOAT:
+    {
+      datum.value<float>() = (float)RFLOAT_VALUE(rb_value);
+      break;
+    }
+    case avro::AVRO_DOUBLE:
+    {
+      datum.value<double>() = RFLOAT_VALUE(rb_value);
+      break;
+    }
+    case avro::AVRO_BOOL:
+    {
+      datum.value<bool>() = rb_value == Qtrue;
+      break;
+    }
+    case avro::AVRO_NULL:
+    {
+      // Nothing todo here
+      break;
+    }
+    case avro::AVRO_RECORD:
+    {
+      ruby_model_to_datum(rb_value, datum);
+      break;
+    }
+    case avro::AVRO_ENUM:
+    {
+      datum.value<avro::GenericEnum>().set(StringValueCStr(rb_value));
+      break;
+    }
+    case avro::AVRO_ARRAY:
+    {
+      avro::GenericArray& arrayValue = datum.value<avro::GenericArray>();
+      VALUE rb_avromatic_item_type = rb_funcall(rb_avromatic_type, rb_intern("value_type"), 0);
+      const long num_values = rb_array_len(rb_value);
+      arrayValue.value().resize(num_values, avro::GenericDatum(arrayValue.schema()->leafAt(0)));
+      for (long i=0; i<num_values; ++i) {
+        VALUE rb_nested_value = rb_ary_entry(rb_value, i);
+        ruby_value_to_datum(rb_nested_value, rb_avromatic_item_type, arrayValue.value()[i]);
+      }
+      break;
+    }
+    case avro::AVRO_MAP:
+    {
+      avro::GenericMap& mapValue = datum.value<avro::GenericMap>();
+      VALUE rb_avromatic_item_type = rb_funcall(rb_avromatic_type, rb_intern("value_type"), 0);
+      // TODO: Avoid allocating the key array by using rb_hash_foreach
+      VALUE rb_keys = rb_funcall(rb_value, rb_intern("keys"), 0);
+      const long num_keys = rb_array_len(rb_keys);
+      mapValue.value().resize(num_keys, std::pair<std::string, avro::GenericDatum>("", avro::GenericDatum(mapValue.schema()->leafAt(1))));
+      for (long i=0; i<num_keys; ++i) {
+        VALUE rb_key = rb_ary_entry(rb_keys, i);
+        VALUE rb_utf8_key = rb_funcall(rb_key, rb_intern("encode"), 1, rb_id2str(rb_intern("utf-8")));
+        // TODO: Does this work correctly with utf-8 characters?
+        mapValue.value()[i].first = StringValueCStr(rb_utf8_key);
+
+        VALUE rb_nested_value = rb_hash_aref(rb_value, rb_key);
+        ruby_value_to_datum(rb_nested_value, rb_avromatic_item_type, mapValue.value()[i].second);
+      }
+      break;
+    }
+    case avro::AVRO_FIXED:
+    {
+      const char* raw_bytes = StringValuePtr(rb_value);
+      const size_t num_bytes = RSTRING_LEN(rb_value);
+      avro::GenericFixed& fixedValue = datum.value<avro::GenericFixed>();
+      fixedValue.value().assign(raw_bytes, raw_bytes + num_bytes);
+      break;
+    }
+    default:
+      rb_raise(rb_eRuntimeError, "Unexpected field type %s", avro::toString(datum.type()).c_str());
+  }
+}
+
+void ruby_model_to_datum(VALUE rb_model, avro::GenericDatum& datum, bool is_value_schema) {
+  avro::GenericRecord& recordDatum = datum.value<avro::GenericRecord>();
+  VALUE rb_attributes = rb_funcall(rb_model, rb_intern("_attributes"), 0);
+  VALUE rb_attribute_definitions = rb_funcall(rb_model, rb_intern("attribute_definitions"), 0);
+  VALUE rb_field_names = is_value_schema ?
+    rb_funcall(rb_model, rb_intern("value_avro_field_names"), 0) :
+    rb_funcall(rb_model, rb_intern("key_avro_field_names"), 0);
+  const long num_fields = rb_array_len(rb_field_names);
+  for (long i=0; i<num_fields; ++i) {
+    VALUE rb_field_name = rb_ary_entry(rb_field_names, i);
+    VALUE rb_field_value = rb_hash_aref(rb_attributes, rb_field_name);
+    VALUE rb_attribute_definition = rb_hash_aref(rb_attribute_definitions, rb_field_name);
+    VALUE rb_avromatic_type = rb_funcall(rb_attribute_definition, rb_intern("type"), 0);
+    const int field_index = (int)recordDatum.fieldIndex(rb_id2name(SYM2ID(rb_field_name)));
+    ruby_value_to_datum(rb_field_value, rb_avromatic_type, recordDatum.fieldAt(field_index));
+  }
+}
+
+VALUE encode_model(VALUE self, VALUE rb_model, VALUE rb_is_value_schema) {
+  bool is_value_schema = rb_is_value_schema == Qtrue;
+  VALUE rb_avro_schema = rb_funcall(rb_model, is_value_schema ? rb_intern("value_avro_schema") : rb_intern("key_avro_schema"), 0);
+  const avro::ValidSchema* schema = get_cached_schema(rb_avro_schema);
+
+  avro::GenericDatum datum(schema->root());
+  try {
+    ruby_model_to_datum(rb_model, datum, is_value_schema);
+  } catch (MissingRequiredAttributeException& e) {
+    // Trigger a full validation to get all error messages
+    rb_funcall(rb_model, rb_intern("avro_validate!"), 0);
+    // The line above should raise an exception but just in case...
+    rb_raise(rb_avromatic_validation_error_class, "%s", e.what());
+  }
+
+  std::unique_ptr<avro::OutputStream> outputStream = avro::memoryOutputStream();
+  avro::EncoderPtr encoder = avro::validatingEncoder(*schema, avro::binaryEncoder());
+  encoder->init(*outputStream);
+  try {
+    avro::encode(*encoder, datum);
+  } catch (const avro::Exception &e) {
+    // This should never happen since the model should be valid at this point but just in case
+    rb_raise(rb_avromatic_validation_error_class, "%s", e.what());
+  }
+
+  std::shared_ptr<std::vector<uint8_t> > outputStreamSnapshot = avro::snapshot(*outputStream);
+  return rb_str_new((char*)&(outputStreamSnapshot->at(0)), outputStreamSnapshot->size());
+}
+
+extern
+void init_avromatic_encoder(VALUE avromatic_native) {
+  rb_avromatic_native_module = avromatic_native;
+  rb_define_singleton_method(rb_avromatic_native_module, "encode_model", RB_FUNC(encode_model), 2);
+
+  VALUE rb_avromatic_module = rb_const_get(rb_cObject, rb_intern("Avromatic"));
+  VALUE rb_model_module = rb_const_get(rb_avromatic_module, rb_intern("Model"));
+  VALUE rb_types_module = rb_const_get(rb_model_module, rb_intern("Types"));
+  rb_avromatic_union_type_class = rb_const_get(rb_types_module, rb_intern("UnionType"));
+  rb_avromatic_custom_type_class = rb_const_get(rb_types_module, rb_intern("CustomType"));
+  rb_avromatic_validation_error_class = rb_const_get(rb_model_module, rb_intern("ValidationError"));
+}

--- a/ext/avromatic/encoder.hpp
+++ b/ext/avromatic/encoder.hpp
@@ -1,0 +1,8 @@
+#ifndef AVROMATIC_ENCODER
+#define AVROMATIC_ENCODER
+
+#include <ruby.h>
+
+void init_avromatic_encoder(VALUE avromatic_native);
+
+#endif

--- a/ext/avromatic/extconf.rb
+++ b/ext/avromatic/extconf.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'mkmf'
+
+have_library 'avrocpp'
+append_cppflags ['-std=c++11', '-Wno-c++11-extensions']
+create_makefile 'avromatic/avromatic'

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -7,14 +7,16 @@ require 'ice_nine/core_ext/object'
 require 'avromatic/model'
 require 'avromatic/model_registry'
 require 'avromatic/messaging'
-require 'active_support/core_ext/string/inflections'
+require 'active_support/all'
+require 'avromatic/avromatic'
 
 module Avromatic
   class << self
     attr_accessor :schema_registry, :registry_url, :schema_store, :logger,
                   :messaging, :custom_type_registry, :nested_models,
                   :use_custom_datum_reader, :use_custom_datum_writer,
-                  :use_schema_fingerprint_lookup, :allow_unknown_attributes
+                  :use_schema_fingerprint_lookup, :allow_unknown_attributes,
+                  :use_native_serialization
 
     delegate :register_type, to: :custom_type_registry
   end
@@ -24,6 +26,7 @@ module Avromatic
   self.custom_type_registry = Avromatic::Model::CustomTypeRegistry.new
   self.use_custom_datum_reader = true
   self.use_custom_datum_writer = true
+  self.use_native_serialization = false
   self.use_schema_fingerprint_lookup = true
   self.allow_unknown_attributes = false
 

--- a/lib/avromatic/model/messaging_serialization.rb
+++ b/lib/avromatic/model/messaging_serialization.rb
@@ -14,18 +14,34 @@ module Avromatic
 
       module Encode
         def avro_message_value
-          avro_messaging.encode(
-            value_attributes_for_avro,
-            schema_name: value_avro_schema.fullname
-          )
+          if Avromatic.use_native_serialization
+            raw = Avromatic::IO::Native.encode_model(self, true)
+            avro_messaging.encode_raw(
+              raw,
+              schema_name: value_avro_schema.fullname
+            )
+          else
+            avro_messaging.encode(
+              value_attributes_for_avro,
+              schema_name: value_avro_schema.fullname
+            )
+          end
         end
 
         def avro_message_key
           raise 'Model has no key schema' unless key_avro_schema
-          avro_messaging.encode(
-            key_attributes_for_avro,
-            schema_name: key_avro_schema.fullname
-          )
+          if Avromatic.use_native_serialization
+            raw = Avromatic::IO::Native.encode_model(self, false)
+            avro_messaging.encode_raw(
+              raw,
+              schema_name: key_avro_schema.fullname
+            )
+          else
+            avro_messaging.encode(
+              key_attributes_for_avro,
+              schema_name: key_avro_schema.fullname
+            )
+          end
         end
       end
       include Encode

--- a/lib/avromatic/model/types/type_factory.rb
+++ b/lib/avromatic/model/types/type_factory.rb
@@ -78,7 +78,7 @@ module Avromatic
                 member_types = member_schemas.map do |member_schema|
                   create(schema: member_schema, nested_models: nested_models, use_custom_types: use_custom_types)
                 end
-                Avromatic::Model::Types::UnionType.new(member_types: member_types)
+                Avromatic::Model::Types::UnionType.new(schema: schema, member_types: member_types)
               end
             when :record
               record_class = build_nested_model(schema: schema, nested_models: nested_models)

--- a/lib/avromatic/model/types/union_type.rb
+++ b/lib/avromatic/model/types/union_type.rb
@@ -9,10 +9,16 @@ module Avromatic
       class UnionType < AbstractType
         attr_reader :member_types, :value_classes, :input_classes
 
-        def initialize(member_types:)
+        # TODO: Should we move the schema up into AbstractType?
+        def initialize(schema:, member_types:)
+          @schema = schema
           @member_types = member_types
           @value_classes = member_types.flat_map(&:value_classes)
           @input_classes = member_types.flat_map(&:input_classes).uniq
+        end
+
+        def nullable?
+          @schema.schemas.first.type_sym == :null
         end
 
         def name
@@ -31,7 +37,8 @@ module Avromatic
             end
           end
 
-          unless result
+          # TODO: Create separate fix
+          if result.nil?
             raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")
           end
 

--- a/spec/avromatic/io/native_spec.rb
+++ b/spec/avromatic/io/native_spec.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+# TODO: We can probably drop this test now in favor of running the whole test suite with different serialization layers
+describe Avromatic::IO::Native do
+  let(:value_schema) { true }
+  let(:test_class) { Avromatic::Model.model(value_schema_name: schema_name) }
+  let(:instance) { test_class.new(attributes) }
+
+  shared_examples_for "a correct encoding roundtrip" do
+    it "encodes properly" do
+      encoded_value = described_class.encode_model(instance, value_schema)
+      expect(encoded_value).to be_a(String)
+      decoded = test_class.avro_raw_decode(value: encoded_value)
+      expect(decoded).to eq(instance)
+    end
+
+    it "decodes properly" do
+      encoded_value = instance.avro_raw_value
+      expect(encoded_value).to be_a(String)
+      decoded_attributes = described_class.decode_attributes(
+        encoded_value,
+        test_class.value_avro_schema,
+        test_class.value_avro_schema,
+        false
+      )
+      decoded = test_class.new(decoded_attributes)
+      expect(decoded).to eq(instance)
+    end
+  end
+
+  context "with a record" do
+    let(:schema_name) { 'test.encode_value' }
+    let(:attributes) { { str1: 'a', str2: 'b' } }
+
+    it_behaves_like "a correct encoding roundtrip"
+  end
+
+  context "primitive types" do
+    let(:schema_name) { 'test.primitive_types' }
+    let(:attributes) do
+      {
+        s: 'foo',
+        b: '123',
+        tf: true,
+        i: 777,
+        l: 123456789,
+        f: 0.5,
+        d: 1.0 / 3.0,
+        n: nil,
+        fx: '1234567',
+        e: 'B'
+      }
+    end
+
+    it_behaves_like "a correct encoding roundtrip"
+  end
+
+  context "with a nested record" do
+    let(:schema_name) { 'test.nested_record' }
+    let(:attributes) { { str: 'a', sub: { str: 'b', i: 1 } } }
+
+    it_behaves_like "a correct encoding roundtrip"
+  end
+
+  context "with an array of primitives" do
+    let(:schema_name) { 'test.with_array' }
+    let(:attributes) { { names: %w[hello world] } }
+
+    it_behaves_like "a correct encoding roundtrip"
+  end
+
+  context "with an array of nested record" do
+    let(:schema) do
+      Avro::Builder.build_schema do
+        record :int_rec do
+          required :i, :int
+        end
+
+        record :transform do
+          required :a, :array, items: :int_rec
+        end
+      end
+    end
+    let(:test_class) do
+      Avromatic::Model.model(schema: schema)
+    end
+    let(:attributes) do
+      {
+        a: [{ i: 1 }, { i: 2 }]
+      }
+    end
+
+    it_behaves_like "a correct encoding roundtrip"
+  end
+
+  context "with a map of primitives" do
+    let(:schema_name) { 'test.with_map' }
+    let(:attributes) { { pairs: { a: 1, b: 2 } } }
+
+    it_behaves_like "a correct encoding roundtrip"
+  end
+
+  context "with a map of nested record" do
+    let(:schema) do
+      Avro::Builder.build_schema do
+        record :int_rec do
+          required :i, :int
+        end
+
+        record :transform do
+          required :m, :map, values: :int_rec
+        end
+      end
+    end
+
+    let(:test_class) do
+      Avromatic::Model.model(schema: schema)
+    end
+
+    let(:attributes) do
+      {
+        m: {
+          a: { i: 1 },
+          b: { i: 2 }
+        }
+      }
+    end
+
+    it_behaves_like "a correct encoding roundtrip"
+  end
+
+  context "with a union of primitives" do
+    let(:schema) do
+      Avro::Builder.build_schema do
+        record :rec do
+          required :u1, union(:string, :boolean, :int)
+          required :u2, union(:string, :boolean, :int)
+          required :u3, union(:string, :boolean, :int)
+        end
+      end
+    end
+
+    let(:test_class) do
+      Avromatic::Model.model(schema: schema)
+    end
+
+    let(:attributes) do
+      {
+        u1: 'hello',
+        u2: true,
+        u3: 7
+      }
+    end
+
+    it_behaves_like "a correct encoding roundtrip"
+  end
+
+  context "with an optional union of primitives" do
+    let(:schema) do
+      Avro::Builder.build_schema do
+        record :rec do
+          optional :u1, union(:string, :boolean, :int)
+          optional :u2, union(:string, :boolean, :int)
+          optional :u3, union(:string, :boolean, :int)
+          optional :u4, union(:string, :boolean, :int)
+        end
+      end
+    end
+
+    let(:test_class) do
+      Avromatic::Model.model(schema: schema)
+    end
+
+    let(:attributes) do
+      {
+        u1: nil,
+        u2: 'hello',
+        u3: true,
+        u4: 7
+      }
+    end
+
+    it_behaves_like "a correct encoding roundtrip"
+  end
+
+  context "with a union nested records" do
+    let(:schema) do
+      Avro::Builder.build_schema do
+        record :a_rec do
+          required :a, :int
+        end
+
+        record :b_rec do
+          required :b, :int
+        end
+
+        record :rec do
+          required :u1, union(:a_rec, :b_rec)
+          required :u2, union(:a_rec, :b_rec)
+        end
+      end
+    end
+
+    let(:test_class) do
+      Avromatic::Model.model(schema: schema)
+    end
+
+    let(:attributes) do
+      {
+        u1: { a: 1 },
+        u2: { b: 2 }
+      }
+    end
+
+    it_behaves_like "a correct encoding roundtrip"
+  end
+
+  context "with optional fields" do
+    let(:schema) do
+      Avro::Builder.build_schema do
+        record :int_rec do
+          required :i, :int
+        end
+
+        record :rec do
+          optional :i1, :int_rec
+          optional :i2, :int_rec
+        end
+      end
+    end
+
+    let(:test_class) do
+      Avromatic::Model.model(schema: schema)
+    end
+
+    let(:attributes) do
+      {
+        i1: { i: 1 },
+        i2: nil
+      }
+    end
+
+    it_behaves_like "a correct encoding roundtrip"
+  end
+
+  context "with logical types" do
+    let(:schema) do
+      Avro::Builder.build_schema do
+        record :rec do
+          required :date, :int, logical_type: 'date'
+          required :ts_msec, :long, logical_type: 'timestamp-millis'
+          required :ts_usec, :long, logical_type: 'timestamp-micros'
+          required :unknown, :int, logical_type: 'foobar'
+        end
+      end
+    end
+
+    let(:test_class) do
+      Avromatic::Model.model(schema: schema)
+    end
+
+    let(:attributes) do
+      {
+        date: Date.today,
+        ts_msec: Time.now,
+        ts_usec: Time.now,
+        unknown: 1
+      }
+    end
+
+    it_behaves_like "a correct encoding roundtrip"
+  end
+
+  context "with custom types that transform on serialization" do
+    let(:schema_name) { 'test.named_type' }
+    let(:attributes) { { six_str: 'foobar' } }
+
+    before do
+      Avromatic.register_type('test.six') do |type|
+        type.to_avro = ->(value) { value.upcase }
+      end
+    end
+
+    it "applies the to_avro callback" do
+      encoded_value = described_class.encode_model(instance, true)
+      decoded = test_class.avro_raw_decode(value: encoded_value)
+      expect(decoded.six_str).to eq('FOOBAR')
+    end
+  end
+
+  context "with custom types that transform on deserialization" do
+    let(:schema_name) { 'test.named_type' }
+    let(:attributes) { { six_str: 'foobar' } }
+
+    before do
+      Avromatic.register_type('test.six') do |type|
+        type.from_avro = ->(value) { value.upcase }
+      end
+    end
+
+    it "applies the to_avro callback" do
+      encoded_value = instance.avro_raw_value
+      decoded_attributes = described_class.decode_attributes(
+        encoded_value,
+        test_class.value_avro_schema,
+        test_class.value_avro_schema,
+        false
+      )
+      decoded = test_class.new(decoded_attributes)
+      expect(decoded.six_str).to eq('FOOBAR')
+    end
+  end
+end


### PR DESCRIPTION
This is a POC of using the [Avro C++](https://avro.apache.org/docs/current/api/cpp/html/index.html) libraries to optimize Avromatic model encoding/decoding. 

# Benchmark Results

All benchmarks results are relative to the Ruby Avro library version [89c03cfe](https://github.com/apache/avro/tree/89c03cfe5fe8a0ad1aacf910e9b94c57a41ea67e) which includes https://github.com/apache/avro/pull/1014.

## Wide Products

Properties: 198
Locales: 75
Localized Property Values: 6,118

### Encoding
```
Calculating -------------------------------------
                ruby      2.354  (± 0.0%) i/s -     69.000  in  30.299116s
              native      3.773  (±26.5%) i/s -    111.000  in  30.229163s

Comparison:
              native:        3.8 i/s
                ruby:        2.4 i/s - 1.60x  slower
```
### Decoding
```
Calculating -------------------------------------
                ruby      4.281  (± 0.0%) i/s -    128.000  in  30.205893s
              native      6.220  (±16.1%) i/s -    186.000  in  30.109659s

Comparison:
              native:        6.2 i/s
                ruby:        4.3 i/s - 1.45x  slower
```
## Standard Products

Properties: 78
Locales: 4
Localized Property Values: 138

### Encoding
```
Calculating -------------------------------------
                ruby    110.135  (±11.8%) i/s -      3.260k in  30.053549s
              native    166.308  (± 8.4%) i/s -      4.960k in  30.087922s

Comparison:
              native:      166.3 i/s
                ruby:      110.1 i/s - 1.51x  slower
```
### Decoding
```
Calculating -------------------------------------
                ruby    182.973  (± 9.8%) i/s -      5.436k in  30.072907s
              native    227.370  (±10.1%) i/s -      6.732k in  30.010797s

Comparison:
              native:      227.4 i/s
                ruby:      183.0 i/s - 1.24x  slower
```
# Language Choice
So why C++? A few reasons:

1. It's fast
2. It has better memory management facilities than C
3. It has an official Avro library
4. It can leverage the MRI C Extension APIs without any additional third party libraries/frameworks

# Implementation
The core of the encoder implementation is in `ext/avromatic/encoder.cpp`. It walks the Ruby Avromatic model tree converting Ruby objects to [avro::GenericDatum](https://avro.apache.org/docs/current/api/cpp/html/classavro_1_1GenericDatum.html) instances. This datum is then serialized using the Avro C++ API. The core of the decoder implementation is in `ext/avromatic/decoder.cpp`. It uses the Avro C++ API to deserialize the Avro binary data into a tree of [avro::GenericDatum](https://avro.apache.org/docs/current/api/cpp/html/classavro_1_1GenericDatum.html) instances. It then walks this tree of datums creating corresponding Ruby objects. There's some complexity due to how Avromatic handles "optional" fields (i.e. union fields whose first member type is null) but otherwise the conversion between Ruby objects and Avro C++ GenericDatums is pretty straightforward.

A word of warning: I haven't written C++ code in about 18 years so I'm more than a little rusty. The mix of snakecase Ruby C APIs and camelcase Avro/STL APIs is also an eyesore.
# Next Steps
The first things we need to figure out are:

1. Do the performance gains justify the complexity of a native extension?
2. Are we happy using C++ vs. other possible languages (e.g. C or Rust)?

If we decide to move forward with this, then we'll have to figure out the following:
* Packaging - Should the native layer be optional to support JRuby or other environments that can't compile the native extension? Where should we get the Avro C++ libraries from?
* A cleaner separation between the Avromatic model layer and the Avromatic serialization layer over the current conditional hacks.
* Avro validation error handling
* Encoding non-primitive custom types
* Figure out C++ coding conventions e.g. snakecase vs. camelcase, indents, etc.
* Proper testing including things like non-ASCII strings and numeric boundary cases

@will89 @cjf2xn @askreet @kphelps - I'm curious for your feedback on this. No rush since I probably won't get back around to working on it for a few weeks.
/cc @salsify/kafka-developers 
