### PR TITLE
Detect already registered nested models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # avromatic changelog
 
+## 3.0.1
+- Raise an error when registering a nested model that has already been auto-generated.
+  This avoids hard to troubleshoot coercion errors when instantiating models and fixes 
+  a regression introduced in Avromatic 2.2.2.
+
 ## 3.0.0
 - Drop support for Ruby 2.4.
 - Add support for Ruby 3.0.

--- a/lib/avromatic/model/nested_models.rb
+++ b/lib/avromatic/model/nested_models.rb
@@ -14,12 +14,14 @@ module Avromatic
         def register!
           return unless key_avro_schema.nil? && value_avro_schema.type_sym == :record
 
+          processed = Set.new
           roots = [self]
           until roots.empty?
             model = roots.shift
-            next if nested_models.registered?(model)
+            # Avoid any nested model dependency cycles by ignoring already processed models
+            next unless processed.add?(model)
 
-            nested_models.register(model)
+            nested_models.ensure_registered_model(model)
             roots.concat(model.referenced_model_classes)
           end
         end

--- a/lib/avromatic/model_registry.rb
+++ b/lib/avromatic/model_registry.rb
@@ -42,8 +42,11 @@ module Avromatic
     def ensure_registered_model(model)
       name = model_fullname(model)
       if registered?(name)
-        unless fetch(name).equal?(model)
-          raise "attempted to replace existing model #{fetch(name)} with new model #{model} as '#{name}'"
+        existing_model = fetch(name)
+        unless existing_model.equal?(model)
+          raise "Attempted to replace existing Avromatic model #{model_debug_name(existing_model)} with new model " \
+            "#{model_debug_name(model)} as '#{name}'. Perhaps '#{model_debug_name(model)}' needs to be eager loaded " \
+            'via the Avromatic eager_load_models setting?'
         end
       else
         register(model)
@@ -64,6 +67,12 @@ module Avromatic
         end
 
       value.start_with?('.') ? value.from(1) : value
+    end
+
+    private
+
+    def model_debug_name(model)
+      model.name || model.to_s
     end
   end
 end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Avromatic
-  VERSION = '3.0.0'
+  VERSION = '3.0.1'
 end

--- a/spec/avromatic/model/builder_nested_models_spec.rb
+++ b/spec/avromatic/model/builder_nested_models_spec.rb
@@ -64,4 +64,14 @@ describe Avromatic::Model::Builder, 'nested_models' do
         .not_to equal(model2.attribute_definitions[:same].type.record_class)
     end
   end
+
+  context "when another instance of the nested model has already been registered" do
+    let!(:outer_model) { described_class.model(schema: schema) }
+
+    it "raises an error" do
+      expect do
+        described_class.model(schema: schema.fields_hash['sub'].type)
+      end.to raise_error(including('Attempted to replace existing Avromatic model'))
+    end
+  end
 end

--- a/spec/avromatic/model_registry_spec.rb
+++ b/spec/avromatic/model_registry_spec.rb
@@ -37,7 +37,7 @@ describe Avromatic::ModelRegistry do
         it "raises an error" do
           expect do
             instance.ensure_registered_model(model.dup)
-          end.to raise_error(including('attempted to replace existing model'))
+          end.to raise_error(including('Attempted to replace existing Avromatic model'))
         end
       end
     end


### PR DESCRIPTION
This PR fixes a regression introduced by #119 that caused Avromatic to not detect models that conflict with already generated models due to improper eager loading configuration. This bug lead to hard to troubleshoot downstream errors like this when instantiating model instances:

```
Avromatic::Model::CoercionError: Value for TargetSchemas::Events::ApplicableScope#field_conditions could not be coerced to a array[FieldCondition]. Provided argument: [#<TargetSchemas::Events::FieldCondition field: #<Core::Events::Reference id: SalsifyUuid('s-8073254e-9d10-487f-8749-a44d04519f1b'), type: "target_schema_fields", external_id: "Field 000000000 ID">, values: ["foo", "bar"], operator: nil, quantifier: nil>]
```

With this bug fix we now get a more actionable error message at model definition time:

```
RuntimeError: Attempted to replace existing Avromatic model FieldCondition with new model TargetSchemas::Events::FieldCondition as 'target_schemas.applicable_scopes.field_condition'. Perhaps 'TargetSchemas::Events::FieldCondition' needs to be eager loaded via the Avromatic eager_load_models setting?
```

@kphelps - you're prime
/cc @salsify/kafka-developers @tjwp 