### PR TITLE
Ensure schema registry caches are cleared between tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # avromatic changelog
 
+## 3.0.2
+- Reset the schema registry client between RSpec tests to ensure any cached values are
+  consistent with the fake schema registry.
+
 ## 3.0.1
 - Raise an error when registering a nested model that has already been auto-generated.
   This avoids hard to troubleshoot coercion errors when instantiating models and fixes 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ and the [Messaging API](#messaging-api).
   so that they can be referenced by id. Either `schema_registry` or
   `registry_url` must be configured.
 * **registry_url**: URL for the schema registry. Either `schema_registry` or 
-  `registry_url` must be configured.
+  `registry_url` must be configured.  The `build_schema_registry!` method may 
+  be used to create a caching schema registry client instance based on other 
+  configuration values.
 * **use_schema_fingerprint_lookup**: Avromatic supports a Schema Registry
   [extension](https://github.com/salsify/avro-schema-registry#extensions) that
   provides an endpoint to lookup existing schema ids by fingerprint.
@@ -91,6 +93,7 @@ Example using a schema registry:
 Avromatic.configure do |config|
   config.schema_store = AvroTurf::SchemaStore.new(path: 'avro/schemas')
   config.registry_url = Rails.configuration.x.avro_schema_registry_url
+  config.build_schema_registry!
   config.build_messaging!
 end
 ```

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -45,6 +45,10 @@ module Avromatic
     end
   end
 
+  def self.build_schema_registry!
+    self.schema_registry = build_schema_registry
+  end
+
   def self.build_messaging
     raise 'Avromatic must be configured with a schema_store' unless schema_store
     Avromatic::Messaging.new(

--- a/lib/avromatic/rspec.rb
+++ b/lib/avromatic/rspec.rb
@@ -12,6 +12,7 @@ RSpec.configure do |config|
 
     WebMock.stub_request(:any, /^#{registry_uri}/).to_rack(AvroSchemaRegistry::FakeServer)
     AvroSchemaRegistry::FakeServer.clear
+    Avromatic.build_schema_registry!
     Avromatic.build_messaging!
   end
 end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Avromatic
-  VERSION = '3.0.1'
+  VERSION = '3.0.2'
 end


### PR DESCRIPTION
This PR updates the RSpec integration to clear schema registry caches are cleared between tests which ensures consistent ID mappings with the `AvroSchemaRegistry::FakeServer`. As part of this fix I added an `Avromatic.build_schema_registry!` method for consistency with the existing `Avromatic.build_messaging!` method. 