### PR TITLE
Remove extraneous files from gem distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## 4.2.0
+- Remove unnecessary files from the gem distribution.
+
 ## 4.1.1
 - Fix eager loading of nested models when using the Zeitwerk classloader with Rails.
 

--- a/avromatic.gemspec
+++ b/avromatic.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
     raise 'RubyGems 2.0 or newer is required to set allowed_push_host.'
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(bin/|lib/|LICENSE.txt)}) }
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']


### PR DESCRIPTION
While debugging I noticed this gem was including several irrelevant files including `.circleci/`, `.github/`, `gemfiles/`, and `log/`. This PR switches to only including the relevant files.

@sgh304 - you're prime