### PR TITLE
Add support for decimal logical type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## 4.3.0
+- Add support for decimal logical type
+
 ## 4.2.0
 - Add an `Avromatic.eager_load_models` attribute reader method.
 - Remove unnecessary files from the gem distribution.

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ The following coercions are supported:
 | Date, Time, DateTime | date |
 | Time, DateTime | timestamp-millis |
 | Time, DateTime | timestamp-micros |
-| String, Numeric | decimal |
+| Numeric | decimal |
 | TrueClass, FalseClass | boolean |
 | NilClass | null |
 | Hash | record |

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ The following coercions are supported:
 | Date, Time, DateTime | date |
 | Time, DateTime | timestamp-millis |
 | Time, DateTime | timestamp-micros |
-| Numeric | decimal |
+| Float, Integer, BigDecimal | decimal |
 | TrueClass, FalseClass | boolean |
 | NilClass | null |
 | Hash | record |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 `Avromatic` generates Ruby models from [Avro](http://avro.apache.org/) schemas
 and provides utilities to encode and decode them.
 
-**This README reflects Avromatic 2.0. Please see the 
+**This README reflects Avromatic 2.0. Please see the
 [1-0-stable](https://github.com/salsify/avromatic/blob/1-0-stable/README.md) branch for Avromatic 1.0.**
 
 ## Installation
@@ -41,7 +41,7 @@ Avromatic with unreleased Avro features.
 * **schema_store**: A schema store is required to load Avro schemas from the filesystem.
   It should be an object that responds to `find(name, namespace = nil)` and
   returns an `Avro::Schema` object. An `AvroTurf::SchemaStore` can be used.
-  The `schema_store` is unnecessary if models are generated directly from 
+  The `schema_store` is unnecessary if models are generated directly from
   `Avro::Schema` objects. See [Models](#models).
 * **nested_models**: An optional [ModelRegistry](https://github.com/salsify/avromatic/blob/master/lib/avromatic/model_registry.rb)
   that is used to store, by full schema name, the generated models that are
@@ -53,8 +53,8 @@ Avromatic with unreleased Avro features.
   option is useful for defining models that will be extended when the load order
   is important.
 * **allow_unknown_attributes**: Optionally allow model constructors to silently
-  ignore unknown attributes. Defaults to `false`. WARNING: Setting this to `true` 
-  will result in incorrect union member coercions if an earlier union member is 
+  ignore unknown attributes. Defaults to `false`. WARNING: Setting this to `true`
+  will result in incorrect union member coercions if an earlier union member is
   satisfied by a subset of the latter union member's attributes.
 
 #### Custom Types
@@ -62,19 +62,19 @@ Avromatic with unreleased Avro features.
 See the section below on configuring [Custom Types](#custom-type-configuration).
 
 #### Using a Schema Registry/Messaging API
- 
-The configuration options below are required when using a schema registry 
+
+The configuration options below are required when using a schema registry
 (see [Confluent Schema Registry](http://docs.confluent.io/2.0.1/schema-registry/docs/intro.html))
 and the [Messaging API](#messaging-api).
-  
+
 * **schema_registry**: An `AvroSchemaRegistry::Client` or
   `AvroTurf::ConfluentSchemaRegistry` object used to store Avro schemas
   so that they can be referenced by id. Either `schema_registry` or
   `registry_url` must be configured. If using `build_schema_registry!`, only
   `registry_url` is required. See example below.
 * **registry_url**: URL for the schema registry. This must be configured when using
-  `build_schema_registry!`. The `build_schema_registry!` method may 
-  be used to create a caching schema registry client instance based on other 
+  `build_schema_registry!`. The `build_schema_registry!` method may
+  be used to create a caching schema registry client instance based on other
   configuration values.
 * **use_schema_fingerprint_lookup**: Avromatic supports a Schema Registry
   [extension](https://github.com/salsify/avro-schema-registry#extensions) that
@@ -113,9 +113,9 @@ to call both.
 
 #### Encoding
 * **use_custom_datum_writer**: `Avromatic` includes a modified subclass of
-  `Avro::IO::DatumWriter`. This subclass supports caching avro encodings for 
-  immutable models and uses additional information about the index of union 
-  members to optimize the encoding of Avro messages. By default this 
+  `Avro::IO::DatumWriter`. This subclass supports caching avro encodings for
+  immutable models and uses additional information about the index of union
+  members to optimize the encoding of Avro messages. By default this
   information is included in the hash passed to the encoder but can be omitted
   by setting this option to `false`.
 
@@ -138,7 +138,7 @@ instance = MyModel.new(id: 123, name: 'Tesla Model 3', enabled: true)
 instance.name # => "Tesla Model 3"
 
 # Models are immutable by default
-instance.name = 'Tesla Model X' # => NoMethodError (private method `name=' called for #<MyModel:0x00007ff711e64e60>) 
+instance.name = 'Tesla Model X' # => NoMethodError (private method `name=' called for #<MyModel:0x00007ff711e64e60>)
 
 # Booleans can also be accessed by '?' readers that coerce nil to false
 instance.enabled? # => true
@@ -309,14 +309,14 @@ end
 ```
 
 The full name of the type and an optional class may be specified. When a class is
-provided then values for attributes of that type are defined using the specified 
+provided then values for attributes of that type are defined using the specified
 class.
 
 If the provided class responds to the class methods `from_avro` and `to_avro`
-then those methods are used to convert values when assigning to the model and 
+then those methods are used to convert values when assigning to the model and
 before encoding using Avro respectively.
 
-`from_avro` and `to_avro` methods may be also be specified as Procs when 
+`from_avro` and `to_avro` methods may be also be specified as Procs when
 registering the type:
 
 ```ruby
@@ -331,7 +331,7 @@ end
 Nil handling is not required as the conversion methods are not be called if the
 inbound or outbound value is nil.
 
-If a custom type is registered for a record-type field, then any `to_avro` 
+If a custom type is registered for a record-type field, then any `to_avro`
 method/Proc should return a Hash with string keys for encoding using Avro.
 
 ### Encoding and Decoding
@@ -364,7 +364,7 @@ MyModel.avro_raw_decode(key: encoded_key, value: encoded_value)
 ```
 
 If the attributes where encoded using a different version of the model's schemas,
-then a new model instance can be created by also providing the schemas used to 
+then a new model instance can be created by also providing the schemas used to
 encode the data:
 
 ```ruby
@@ -417,7 +417,7 @@ MyTopic.register_schemas!
 #### Avromatic::Model::MessageDecoder
 
 A stream of messages encoded from various models using the messaging approach
-can be decoded using `Avromatic::Model::MessageDecoder`. The decoder must be 
+can be decoded using `Avromatic::Model::MessageDecoder`. The decoder must be
 initialized with the list of models to decode:
 
 ```ruby
@@ -447,12 +447,13 @@ The following coercions are supported:
 | Date, Time, DateTime | date |
 | Time, DateTime | timestamp-millis |
 | Time, DateTime | timestamp-micros |
+| String, Numeric | decimal |
 | TrueClass, FalseClass | boolean |
 | NilClass | null |
 | Hash | record |
 
 Validation of required fields is done automatically when serializing a model to Avro. It can also be done
-explicitly by calling the `valid?` or `invalid?` methods from the 
+explicitly by calling the `valid?` or `invalid?` methods from the
 [ActiveModel::Validations](https://edgeapi.rubyonrails.org/classes/ActiveModel/Validations.html) interface.
 
 ### RSpec Support

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -90,6 +90,10 @@ module Avromatic
     @eager_load_model_names&.each { |model_name| model_name.constantize.register! }
   end
   private_class_method :eager_load_models!
+
+  def self.allow_decimal_logical_type
+    ::Gem::Requirement.new('>= 1.11.0').satisfied_by?(::Gem::Version.new(::Avro::VERSION))
+  end
 end
 
 require 'avromatic/railtie' if defined?(Rails)

--- a/lib/avromatic.rb
+++ b/lib/avromatic.rb
@@ -91,7 +91,7 @@ module Avromatic
   end
   private_class_method :eager_load_models!
 
-  def self.allow_decimal_logical_type
+  def self.allow_decimal_logical_type?
     ::Gem::Requirement.new('>= 1.11.0').satisfied_by?(::Gem::Version.new(::Avro::VERSION))
   end
 end

--- a/lib/avromatic/model/types/decimal_type.rb
+++ b/lib/avromatic/model/types/decimal_type.rb
@@ -10,8 +10,14 @@ module Avromatic
       class DecimalType < AbstractType
         VALUE_CLASSES = [::BigDecimal].freeze
         INPUT_CLASSES = [::Numeric, ::String].freeze
-        DEFAULT_PRECISION = 3
-        private_constant :DEFAULT_PRECISION
+
+        attr_reader :precision, :scale
+
+        def initialize(precision:, scale: 0)
+          super()
+          @precision = precision
+          @scale = scale
+        end
 
         def value_classes
           VALUE_CLASSES
@@ -22,7 +28,7 @@ module Avromatic
         end
 
         def name
-          'decimal'
+          "decimal(#{precision}, #{scale})"
         end
 
         def coerce(input)
@@ -30,7 +36,7 @@ module Avromatic
           when ::NilClass, ::BigDecimal
             input
           when ::Rational
-            input.to_d(DEFAULT_PRECISION)
+            input.to_d(precision)
           when ::Numeric, ::String
             input.to_d
           else

--- a/lib/avromatic/model/types/decimal_type.rb
+++ b/lib/avromatic/model/types/decimal_type.rb
@@ -9,7 +9,6 @@ module Avromatic
     module Types
       class DecimalType < AbstractType
         VALUE_CLASSES = [::Numeric].freeze
-        INPUT_CLASSES = [::Numeric, ::String].freeze
 
         attr_reader :precision, :scale
 
@@ -23,10 +22,6 @@ module Avromatic
           VALUE_CLASSES
         end
 
-        def input_classes
-          INPUT_CLASSES
-        end
-
         def name
           "decimal(#{precision}, #{scale})"
         end
@@ -37,7 +32,7 @@ module Avromatic
             input
           when ::Rational
             input.to_d(precision)
-          when ::Numeric, ::String
+          when ::Numeric
             input.to_d
           else
             raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")
@@ -45,7 +40,7 @@ module Avromatic
         end
 
         def coercible?(input)
-          input.nil? || input.is_a?(::String) || input.is_a?(::Numeric)
+          input.nil? || input.is_a?(::Numeric)
         end
 
         def coerced?(input)

--- a/lib/avromatic/model/types/decimal_type.rb
+++ b/lib/avromatic/model/types/decimal_type.rb
@@ -30,8 +30,6 @@ module Avromatic
           case input
           when ::NilClass, ::BigDecimal
             input
-          when ::Rational
-            input.to_d(precision)
           when ::Numeric
             input.to_d
           else

--- a/lib/avromatic/model/types/decimal_type.rb
+++ b/lib/avromatic/model/types/decimal_type.rb
@@ -8,7 +8,7 @@ module Avromatic
   module Model
     module Types
       class DecimalType < AbstractType
-        VALUE_CLASSES = [::BigDecimal].freeze
+        VALUE_CLASSES = [::Numeric].freeze
         INPUT_CLASSES = [::Numeric, ::String].freeze
 
         attr_reader :precision, :scale

--- a/lib/avromatic/model/types/decimal_type.rb
+++ b/lib/avromatic/model/types/decimal_type.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'bigdecimal'
+require 'bigdecimal/util'
+require 'avromatic/model/types/abstract_type'
+
+module Avromatic
+  module Model
+    module Types
+      class DecimalType < AbstractType
+        VALUE_CLASSES = [::BigDecimal].freeze
+        INPUT_CLASSES = [::Numeric, ::String].freeze
+        DEFAULT_PRECISION = 3
+        private_constant :DEFAULT_PRECISION
+
+        def value_classes
+          VALUE_CLASSES
+        end
+
+        def input_classes
+          INPUT_CLASSES
+        end
+
+        def name
+          'decimal'
+        end
+
+        def coerce(input)
+          case input
+          when ::NilClass, ::BigDecimal
+            input
+          when ::Rational
+            input.to_d(DEFAULT_PRECISION)
+          when ::Numeric, ::String
+            input.to_d
+          else
+            raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")
+          end
+        end
+
+        def coercible?(input)
+          input.nil? || input.is_a?(::String) || input.is_a?(::Numeric)
+        end
+
+        def coerced?(input)
+          input.nil? || input.is_a?(::BigDecimal)
+        end
+
+        def serialize(value, _strict)
+          value
+        end
+
+        def referenced_model_classes
+          EMPTY_ARRAY
+        end
+      end
+    end
+  end
+end

--- a/lib/avromatic/model/types/decimal_type.rb
+++ b/lib/avromatic/model/types/decimal_type.rb
@@ -8,7 +8,7 @@ module Avromatic
   module Model
     module Types
       class DecimalType < AbstractType
-        VALUE_CLASSES = [::Numeric].freeze
+        VALUE_CLASSES = [::BigDecimal, ::Float, ::Integer].freeze
 
         attr_reader :precision, :scale
 
@@ -30,7 +30,7 @@ module Avromatic
           case input
           when ::NilClass, ::BigDecimal
             input
-          when ::Numeric
+          when ::Float, ::Integer
             input.to_d
           else
             raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")
@@ -38,7 +38,7 @@ module Avromatic
         end
 
         def coercible?(input)
-          input.nil? || input.is_a?(::Numeric)
+          input.nil? || input_classes.any? { |input_class| input.is_a?(input_class) }
         end
 
         def coerced?(input)

--- a/lib/avromatic/model/types/decimal_type.rb
+++ b/lib/avromatic/model/types/decimal_type.rb
@@ -8,7 +8,8 @@ module Avromatic
   module Model
     module Types
       class DecimalType < AbstractType
-        VALUE_CLASSES = [::BigDecimal, ::Float, ::Integer].freeze
+        VALUE_CLASSES = [::BigDecimal].freeze
+        INPUT_CLASSES = [::BigDecimal, ::Float, ::Integer].freeze
 
         attr_reader :precision, :scale
 
@@ -20,6 +21,10 @@ module Avromatic
 
         def value_classes
           VALUE_CLASSES
+        end
+
+        def input_classes
+          INPUT_CLASSES
         end
 
         def name
@@ -41,8 +46,8 @@ module Avromatic
           input.nil? || input_classes.any? { |input_class| input.is_a?(input_class) }
         end
 
-        def coerced?(input)
-          input.nil? || input.is_a?(::BigDecimal)
+        def coerced?(value)
+          value.nil? || value_classes.any? { |value_class| value.is_a?(value_class) }
         end
 
         def serialize(value, _strict)

--- a/lib/avromatic/model/types/type_factory.rb
+++ b/lib/avromatic/model/types/type_factory.rb
@@ -52,7 +52,7 @@ module Avromatic
           elsif schema.respond_to?(:logical_type) && SINGLETON_TYPES.include?(schema.logical_type)
             SINGLETON_TYPES.fetch(schema.logical_type)
           elsif schema.respond_to?(:logical_type) && schema.logical_type == 'decimal' &&
-                Avromatic.allow_decimal_logical_type
+                Avromatic.allow_decimal_logical_type?
             Avromatic::Model::Types::DecimalType.new(precision: schema.precision, scale: schema.scale || 0)
           elsif SINGLETON_TYPES.include?(schema.type)
             SINGLETON_TYPES.fetch(schema.type)

--- a/lib/avromatic/model/types/type_factory.rb
+++ b/lib/avromatic/model/types/type_factory.rb
@@ -4,6 +4,7 @@ require 'avromatic/model/types/array_type'
 require 'avromatic/model/types/boolean_type'
 require 'avromatic/model/types/custom_type'
 require 'avromatic/model/types/date_type'
+require 'avromatic/model/types/decimal_type'
 require 'avromatic/model/types/enum_type'
 require 'avromatic/model/types/fixed_type'
 require 'avromatic/model/types/float_type'
@@ -26,6 +27,7 @@ module Avromatic
           'date' => Avromatic::Model::Types::DateType.new,
           'timestamp-micros' => Avromatic::Model::Types::TimestampMicrosType.new,
           'timestamp-millis' => Avromatic::Model::Types::TimestampMillisType.new,
+          'decimal' => Avromatic::Model::Types::DecimalType.new,
           'string' => Avromatic::Model::Types::StringType.new,
           'bytes' => Avromatic::Model::Types::StringType.new,
           'boolean' => Avromatic::Model::Types::BooleanType.new,

--- a/lib/avromatic/model/types/type_factory.rb
+++ b/lib/avromatic/model/types/type_factory.rb
@@ -27,7 +27,6 @@ module Avromatic
           'date' => Avromatic::Model::Types::DateType.new,
           'timestamp-micros' => Avromatic::Model::Types::TimestampMicrosType.new,
           'timestamp-millis' => Avromatic::Model::Types::TimestampMillisType.new,
-          'decimal' => Avromatic::Model::Types::DecimalType.new,
           'string' => Avromatic::Model::Types::StringType.new,
           'bytes' => Avromatic::Model::Types::StringType.new,
           'boolean' => Avromatic::Model::Types::BooleanType.new,
@@ -52,6 +51,8 @@ module Avromatic
             )
           elsif schema.respond_to?(:logical_type) && SINGLETON_TYPES.include?(schema.logical_type)
             SINGLETON_TYPES.fetch(schema.logical_type)
+          elsif schema.respond_to?(:logical_type) && schema.logical_type == 'decimal'
+            Avromatic::Model::Types::DecimalType.new(precision: schema.precision, scale: schema.scale || 0)
           elsif SINGLETON_TYPES.include?(schema.type)
             SINGLETON_TYPES.fetch(schema.type)
           else

--- a/lib/avromatic/model/types/type_factory.rb
+++ b/lib/avromatic/model/types/type_factory.rb
@@ -51,7 +51,8 @@ module Avromatic
             )
           elsif schema.respond_to?(:logical_type) && SINGLETON_TYPES.include?(schema.logical_type)
             SINGLETON_TYPES.fetch(schema.logical_type)
-          elsif schema.respond_to?(:logical_type) && schema.logical_type == 'decimal'
+          elsif schema.respond_to?(:logical_type) && schema.logical_type == 'decimal' &&
+                Avromatic.allow_decimal_logical_type
             Avromatic::Model::Types::DecimalType.new(precision: schema.precision, scale: schema.scale || 0)
           elsif SINGLETON_TYPES.include?(schema.type)
             SINGLETON_TYPES.fetch(schema.type)

--- a/spec/avro/dsl/test/logical_types.rb
+++ b/spec/avro/dsl/test/logical_types.rb
@@ -4,6 +4,6 @@ record :logical_types, namespace: :test do
   required :date, :int, logical_type: 'date'
   required :ts_msec, :long, logical_type: 'timestamp-millis'
   required :ts_usec, :long, logical_type: 'timestamp-micros'
-  required :decimal, :bytes, logical_type: 'decimal', precision: 4
+  required :decimal, :bytes, logical_type: 'decimal', precision: 4, scale: 2
   required :unknown, :int, logical_type: 'foobar'
 end

--- a/spec/avro/dsl/test/logical_types.rb
+++ b/spec/avro/dsl/test/logical_types.rb
@@ -4,5 +4,6 @@ record :logical_types, namespace: :test do
   required :date, :int, logical_type: 'date'
   required :ts_msec, :long, logical_type: 'timestamp-millis'
   required :ts_usec, :long, logical_type: 'timestamp-micros'
+  required :decimal, :bytes, logical_type: 'decimal', precision: 4
   required :unknown, :int, logical_type: 'foobar'
 end

--- a/spec/avro/schema/test/logical_types.avsc
+++ b/spec/avro/schema/test/logical_types.avsc
@@ -25,6 +25,15 @@
       }
     },
     {
+      "name": "decimal",
+      "type": {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "precision": 4,
+        "scale": 2
+      }
+    },
+    {
       "name": "unknown",
       "type": {
         "type": "int",

--- a/spec/avro/schema/test/logical_types_with_decimal.avsc
+++ b/spec/avro/schema/test/logical_types_with_decimal.avsc
@@ -1,6 +1,6 @@
 {
   "type": "record",
-  "name": "logical_types",
+  "name": "logical_types_with_decimal",
   "namespace": "test",
   "fields": [
     {
@@ -22,6 +22,15 @@
       "type": {
         "type": "long",
         "logicalType": "timestamp-micros"
+      }
+    },
+    {
+      "name": "decimal",
+      "type": {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "precision": 4,
+        "scale": 2
       }
     },
     {

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -349,7 +349,7 @@ describe Avromatic::Model::Builder do
 
     context "logical types" do
       let(:schema_name) do
-        Avromatic.allow_decimal_logical_type ? 'test.logical_types_with_decimal' : 'test.logical_types'
+        Avromatic.allow_decimal_logical_type? ? 'test.logical_types_with_decimal' : 'test.logical_types'
       end
 
       it_behaves_like "a generated model"
@@ -433,7 +433,7 @@ describe Avromatic::Model::Builder do
         end
       end
 
-      context "decimal", skip: !Avromatic.allow_decimal_logical_type do
+      context "decimal", skip: !Avromatic.allow_decimal_logical_type? do
         it "accepts a BigDecimal" do
           decimal = BigDecimal('3.4562')
           instance = test_class.new(decimal: decimal)
@@ -1163,7 +1163,7 @@ describe Avromatic::Model::Builder do
         end
       end
 
-      context "union with a decimal", skip: !Avromatic.allow_decimal_logical_type do
+      context "union with a decimal", skip: !Avromatic.allow_decimal_logical_type? do
         let(:schema) do
           Avro::Builder.build_schema do
             record :with_decimal_union do

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -445,12 +445,6 @@ describe Avromatic::Model::Builder do
           expect(instance.decimal).to eq(42.to_d)
         end
 
-        it "accepts a Rational" do
-          rational = 2 / 3r
-          instance = test_class.new(decimal: rational)
-          expect(instance.decimal).to eq(rational.to_d(4))
-        end
-
         it "accepts a Float" do
           float = 5.23
           instance = test_class.new(decimal: float)

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -430,6 +430,37 @@ describe Avromatic::Model::Builder do
           expect { test_class.new(date: 'today') }.to raise_error(Avromatic::Model::CoercionError)
         end
       end
+
+      context "decimal" do
+        it "accepts a BigDecimal" do
+          decimal = BigDecimal('3.4562')
+          instance = test_class.new(decimal: decimal)
+          expect(instance.decimal).to eq(decimal)
+        end
+
+        it "accepts a String" do
+          string = '3.4562'
+          instance = test_class.new(decimal: string)
+          expect(instance.decimal).to eq(string.to_d)
+        end
+
+        it "accepts an Integer" do
+          instance = test_class.new(decimal: 42)
+          expect(instance.decimal).to eq(42.to_d)
+        end
+
+        it "accepts a Rational" do
+          rational = 2/3r
+          instance = test_class.new(decimal: rational)
+          expect(instance.decimal).to eq(rational.to_d(3))
+        end
+
+        it "accepts a Float" do
+          float = 5.23
+          instance = test_class.new(decimal: float)
+          expect(instance.decimal).to eq(float.to_d)
+        end
+      end
     end
 
     context "recursive models" do
@@ -1139,6 +1170,22 @@ describe Avromatic::Model::Builder do
           now = Date.today
           instance = test_class.new(u: now)
           expect(instance.u).to eq(now)
+        end
+      end
+
+      context "union with a decimal" do
+        let(:schema) do
+          Avro::Builder.build_schema do
+            record :with_decimal_union do
+              required :u, :union, types: [:string, bytes(logical_type: 'decimal', precision: 4)]
+            end
+          end
+        end
+
+        it "coerces numeric to a union member" do
+          numeric = 42.42
+          instance = test_class.new(u: numeric)
+          expect(instance.u).to eq(numeric.to_d)
         end
       end
     end

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -348,7 +348,9 @@ describe Avromatic::Model::Builder do
     end
 
     context "logical types" do
-      let(:schema_name) { 'test.logical_types' }
+      let(:schema_name) do
+        Avromatic.allow_decimal_logical_type ? 'test.logical_types_with_decimal' : 'test.logical_types'
+      end
 
       it_behaves_like "a generated model"
 
@@ -431,7 +433,7 @@ describe Avromatic::Model::Builder do
         end
       end
 
-      context "decimal" do
+      context "decimal", skip: !Avromatic.allow_decimal_logical_type do
         it "accepts a BigDecimal" do
           decimal = BigDecimal('3.4562')
           instance = test_class.new(decimal: decimal)
@@ -1173,7 +1175,7 @@ describe Avromatic::Model::Builder do
         end
       end
 
-      context "union with a decimal" do
+      context "union with a decimal", skip: !Avromatic.allow_decimal_logical_type do
         let(:schema) do
           Avro::Builder.build_schema do
             record :with_decimal_union do

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -440,12 +440,6 @@ describe Avromatic::Model::Builder do
           expect(instance.decimal).to eq(decimal)
         end
 
-        it "accepts a String" do
-          string = '3.4562asd'
-          instance = test_class.new(decimal: string)
-          expect(instance.decimal).to eq(string.to_d)
-        end
-
         it "accepts an Integer" do
           instance = test_class.new(decimal: 42)
           expect(instance.decimal).to eq(42.to_d)

--- a/spec/avromatic/model/builder_spec.rb
+++ b/spec/avromatic/model/builder_spec.rb
@@ -439,7 +439,7 @@ describe Avromatic::Model::Builder do
         end
 
         it "accepts a String" do
-          string = '3.4562'
+          string = '3.4562asd'
           instance = test_class.new(decimal: string)
           expect(instance.decimal).to eq(string.to_d)
         end
@@ -450,9 +450,9 @@ describe Avromatic::Model::Builder do
         end
 
         it "accepts a Rational" do
-          rational = 2/3r
+          rational = 2 / 3r
           instance = test_class.new(decimal: rational)
-          expect(instance.decimal).to eq(rational.to_d(3))
+          expect(instance.decimal).to eq(rational.to_d(4))
         end
 
         it "accepts a Float" do

--- a/spec/support/contexts/logical_types_serialization.rb
+++ b/spec/support/contexts/logical_types_serialization.rb
@@ -4,7 +4,9 @@
 #   decoded: a model instance based on the encoded_value
 shared_examples_for "logical type encoding and decoding" do
   context "logical types" do
-    let(:schema_name) { 'test.logical_types' }
+    let(:schema_name) do
+      Avromatic.allow_decimal_logical_type ? 'test.logical_types_with_decimal' : 'test.logical_types'
+    end
     let(:test_class) do
       Avromatic::Model.model(schema_name: schema_name)
     end
@@ -25,9 +27,8 @@ shared_examples_for "logical type encoding and decoding" do
             date: Date.today,
             ts_msec: now,
             ts_usec: now,
-            decimal: BigDecimal('5.2'),
             unknown: 42
-          }
+          }.tap { _1[:decimal] = BigDecimal('5.2') if Avromatic.allow_decimal_logical_type }
         end
 
         it "encodes and decodes instances" do
@@ -44,9 +45,8 @@ shared_examples_for "logical type encoding and decoding" do
             date: (Date.today - epoch_start).to_i,
             ts_msec: now.to_i + now.usec / 1000 * 1000,
             ts_usec: now.to_i * 1_000_000 + now.usec,
-            decimal: BigDecimal('1.5432'),
             unknown: 42
-          }
+          }.tap { _1[:decimal] = BigDecimal('1.5432') if Avromatic.allow_decimal_logical_type }
         end
 
         it "encodes and decodes instances" do

--- a/spec/support/contexts/logical_types_serialization.rb
+++ b/spec/support/contexts/logical_types_serialization.rb
@@ -25,6 +25,7 @@ shared_examples_for "logical type encoding and decoding" do
             date: Date.today,
             ts_msec: now,
             ts_usec: now,
+            decimal: BigDecimal('5.2'),
             unknown: 42
           }
         end
@@ -43,6 +44,7 @@ shared_examples_for "logical type encoding and decoding" do
             date: (Date.today - epoch_start).to_i,
             ts_msec: now.to_i + now.usec / 1000 * 1000,
             ts_usec: now.to_i * 1_000_000 + now.usec,
+            decimal: BigDecimal('1.5432'),
             unknown: 42
           }
         end

--- a/spec/support/contexts/logical_types_serialization.rb
+++ b/spec/support/contexts/logical_types_serialization.rb
@@ -5,7 +5,7 @@
 shared_examples_for "logical type encoding and decoding" do
   context "logical types" do
     let(:schema_name) do
-      Avromatic.allow_decimal_logical_type ? 'test.logical_types_with_decimal' : 'test.logical_types'
+      Avromatic.allow_decimal_logical_type? ? 'test.logical_types_with_decimal' : 'test.logical_types'
     end
     let(:test_class) do
       Avromatic::Model.model(schema_name: schema_name)
@@ -28,7 +28,7 @@ shared_examples_for "logical type encoding and decoding" do
             ts_msec: now,
             ts_usec: now,
             unknown: 42
-          }.tap { _1[:decimal] = BigDecimal('5.2') if Avromatic.allow_decimal_logical_type }
+          }.tap { _1[:decimal] = BigDecimal('5.2') if Avromatic.allow_decimal_logical_type? }
         end
 
         it "encodes and decodes instances" do
@@ -46,7 +46,7 @@ shared_examples_for "logical type encoding and decoding" do
             ts_msec: now.to_i + now.usec / 1000 * 1000,
             ts_usec: now.to_i * 1_000_000 + now.usec,
             unknown: 42
-          }.tap { _1[:decimal] = BigDecimal('1.5432') if Avromatic.allow_decimal_logical_type }
+          }.tap { _1[:decimal] = BigDecimal('1.5432') if Avromatic.allow_decimal_logical_type? }
         end
 
         it "encodes and decodes instances" do


### PR DESCRIPTION
It adds support for the decimal logical type, so the following Avro schema can be processed correctly:
```json
{
  "type": "bytes",
  "logicalType": "decimal",
  "precision": 4,
  "scale": 2
}
```
However, It's only supported by the Avro v1.11.x. If that's ok, I'm open for suggestions how to better restrict that feature to supported avro version.

https://avro.apache.org/docs/1.11.1/specification/#decimal