### PR TITLE
Updates readme to make it a little clearer when configuring a schema registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Avromatic.configure do |config|
 end
 ```
 
-NOTE: `build_message!` ultimately calls `build_schema_registry!` so you don't have
+NOTE: `build_messaging!` ultimately calls `build_schema_registry!` so you don't have
 to call both.
 
 #### Decoding

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ Avromatic.configure do |config|
 end
 ```
 
+NOTE: `build_message!` ultimately calls `build_schema_registry!` so you don't have
+to call both.
+
 #### Decoding
 
 * **use_custom_datum_reader**: `Avromatic` includes a modified subclass of

--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ and the [Messaging API](#messaging-api).
 * **schema_registry**: An `AvroSchemaRegistry::Client` or
   `AvroTurf::ConfluentSchemaRegistry` object used to store Avro schemas
   so that they can be referenced by id. Either `schema_registry` or
-  `registry_url` must be configured.
-* **registry_url**: URL for the schema registry. Either `schema_registry` or 
-  `registry_url` must be configured.  The `build_schema_registry!` method may 
+  `registry_url` must be configured. If using `build_schema_registry!`, only
+  `registry_url` is required. See example below.
+* **registry_url**: URL for the schema registry. This must be configured when using
+  `build_schema_registry!`. The `build_schema_registry!` method may 
   be used to create a caching schema registry client instance based on other 
   configuration values.
 * **use_schema_fingerprint_lookup**: Avromatic supports a Schema Registry
@@ -93,7 +94,7 @@ Example using a schema registry:
 Avromatic.configure do |config|
   config.schema_store = AvroTurf::SchemaStore.new(path: 'avro/schemas')
   config.registry_url = Rails.configuration.x.avro_schema_registry_url
-  config.build_schema_registry!
+
   config.build_messaging!
 end
 ```


### PR DESCRIPTION
This PR updates the README to make it a little clearer when configuring a schema registry that you have the option to either provide an instance of a compatible registry object or just specify the registry_url. `build_schema_registry` uses the registry_url to instantiate an instance of a compatible registry class.

Setting schema_registry and a registry_url, followed by a call to build_schema_registry will override whatever was passed in as the value of schema_registry with the instantiation of the ConfluentSchemaRegistry instance configured with the registry_url.

This also updates the example to show that `build_messaging` will call `build_schema_registry`. That both do not need to be called explicitly (at least when providing registry_url).