### PR TITLE
fixed issues with bigint 

### DIFF
--- a/lib/avromatic/model/types/big_int_type.rb
+++ b/lib/avromatic/model/types/big_int_type.rb
@@ -8,7 +8,7 @@ module Avromatic
       class BigIntType < AbstractType
         VALUE_CLASSES = [::Integer].freeze
 
-        MAX_RANGE = 2 ** 63
+        MAX_RANGE = 2**63
 
         def value_classes
           VALUE_CLASSES

--- a/lib/avromatic/model/types/big_int_type.rb
+++ b/lib/avromatic/model/types/big_int_type.rb
@@ -5,21 +5,21 @@ require 'avromatic/model/types/abstract_type'
 module Avromatic
   module Model
     module Types
-      class IntegerType < AbstractType
+      class BigIntType < AbstractType
         VALUE_CLASSES = [::Integer].freeze
 
-        MAX_RANGE = 2 ** 31
+        MAX_RANGE = 2 ** 63
 
         def value_classes
           VALUE_CLASSES
         end
 
         def name
-          'integer'
+          'bigint'
         end
 
         def coerce(input)
-          if input.nil? || input.is_a?(::Integer)
+          if coercible?(input)
             input
           else
             raise ArgumentError.new("Could not coerce '#{input.inspect}' to #{name}")

--- a/lib/avromatic/model/types/integer_type.rb
+++ b/lib/avromatic/model/types/integer_type.rb
@@ -8,7 +8,7 @@ module Avromatic
       class IntegerType < AbstractType
         VALUE_CLASSES = [::Integer].freeze
 
-        MAX_RANGE = 2 ** 31
+        MAX_RANGE = 2**31
 
         def value_classes
           VALUE_CLASSES

--- a/lib/avromatic/model/types/type_factory.rb
+++ b/lib/avromatic/model/types/type_factory.rb
@@ -8,6 +8,7 @@ require 'avromatic/model/types/enum_type'
 require 'avromatic/model/types/fixed_type'
 require 'avromatic/model/types/float_type'
 require 'avromatic/model/types/integer_type'
+require 'avromatic/model/types/big_int_type'
 require 'avromatic/model/types/map_type'
 require 'avromatic/model/types/null_type'
 require 'avromatic/model/types/record_type'
@@ -30,7 +31,7 @@ module Avromatic
           'bytes' => Avromatic::Model::Types::StringType.new,
           'boolean' => Avromatic::Model::Types::BooleanType.new,
           'int' => Avromatic::Model::Types::IntegerType.new,
-          'long' => Avromatic::Model::Types::IntegerType.new,
+          'long' => Avromatic::Model::Types::BigIntType.new,
           'float' => Avromatic::Model::Types::FloatType.new,
           'double' => Avromatic::Model::Types::FloatType.new,
           'null' => Avromatic::Model::Types::NullType.new

--- a/spec/avromatic/io/datum_reader_spec.rb
+++ b/spec/avromatic/io/datum_reader_spec.rb
@@ -44,7 +44,7 @@ describe Avromatic::IO::DatumReader do
         b: '123',
         tf: true,
         i: rand(10),
-        l: 123456789,
+        l: 2 ** 40,
         f: 0.5,
         d: 1.0 / 3.0,
         n: nil,

--- a/spec/avromatic/io/datum_reader_spec.rb
+++ b/spec/avromatic/io/datum_reader_spec.rb
@@ -44,7 +44,7 @@ describe Avromatic::IO::DatumReader do
         b: '123',
         tf: true,
         i: rand(10),
-        l: 2 ** 40,
+        l: 2**40,
         f: 0.5,
         d: 1.0 / 3.0,
         n: nil,


### PR DESCRIPTION
Added ranges for int and bigint according to specs

This fix allows handling situations where `int` and `long` are present and covers issues like:

`Avro::IO::AvroTypeError: The datum 3324284763061284583 is not an example of schema "int"`



