### PR TITLE
Release 4.3.0

### DIFF
--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Avromatic
-  VERSION = '4.2.0'
+  VERSION = '4.3.0'
 end


### PR DESCRIPTION
Trigger a release of 4.3.0 which includes support for the decimal logical type introduced in https://github.com/salsify/avromatic/pull/151.

@gremerritt - you're prime