### PR TITLE
[PIMCORE-2190] Fix writing non-big ints to `long` unions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avromatic changelog
 
+## 5.2.1
+- Fixed writing small ints to unions with `long` member type.
+
 ## 5.2.0
 - Add support for Rails 8.0
 

--- a/lib/avromatic/model/types/union_type.rb
+++ b/lib/avromatic/model/types/union_type.rb
@@ -78,7 +78,8 @@ module Avromatic
         def find_index(value)
           if value.is_a?(::Integer)
             if Avromatic::Model::Types::IntegerType.in_range?(value)
-              return member_types.index { |member_type| member_type.is_a?(Avromatic::Model::Types::IntegerType) }
+              return member_types.index { |member_type| member_type.is_a?(Avromatic::Model::Types::IntegerType) } ||
+                     member_types.index { |member_type| member_type.is_a?(Avromatic::Model::Types::BigIntType) }
             elsif Avromatic::Model::Types::BigIntType.in_range?(value)
               return member_types.index { |member_type| member_type.is_a?(Avromatic::Model::Types::BigIntType) }
             end

--- a/lib/avromatic/version.rb
+++ b/lib/avromatic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Avromatic
-  VERSION = '5.2.0'
+  VERSION = '5.2.1'
 end

--- a/spec/avro/dsl/test/real_int_union.rb
+++ b/spec/avro/dsl/test/real_int_union.rb
@@ -5,4 +5,5 @@ namespace :test
 record :real_int_union do
   required :header, :string
   required :message, :union, types: [:int, :string, :long]
+  optional :string_or_long, :union, types: [:string, :long]
 end

--- a/spec/avro/schema/test/real_int_union.avsc
+++ b/spec/avro/schema/test/real_int_union.avsc
@@ -14,6 +14,15 @@
         "string",
         "long"
       ]
+    },
+    {
+      "name": "string_or_long",
+      "type": [
+        "null",
+        "string",
+        "long"
+      ],
+      "default": null
     }
   ]
 }

--- a/spec/avromatic/io/datum_writer_spec.rb
+++ b/spec/avromatic/io/datum_writer_spec.rb
@@ -60,7 +60,8 @@ describe Avromatic::IO::DatumWriter do
       let(:values) do
         {
           header: 'foo',
-          message: 1
+          message: 1,
+          string_or_long: 1
         }
       end
 


### PR DESCRIPTION
#166 introduced a bug writing a non-big int to a union that only has `long` as the supported int type.

> Expected 1 to be one of ["String", "Integer"]

This PR fixes the bug by also looking for a `BigIntType` member type.

prime: @jturkel 

[PIMCORE-2190]

[PIMCORE-2190]: https://salsify.atlassian.net/browse/PIMCORE-2190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ